### PR TITLE
fix: resolve lint errors breaking CI

### DIFF
--- a/src/components/gaming/rps-game.tsx
+++ b/src/components/gaming/rps-game.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback, useEffect, useRef } from "react"
+import { useState, useCallback, useRef } from "react"
 import { useWallet } from "@solana/wallet-adapter-react"
 import { useDemoModeStore } from "@/stores/demo-mode"
 import { DemoBanner } from "@/components/ui/demo-banner"
@@ -68,15 +68,12 @@ export function RpsGame({ game, onBack }: RpsGameProps) {
   const canPlay = (connected || isDemoMode) && phase === "select"
 
   // Generate opponent commitment when player selects a move
-  useEffect(() => {
-    if (playerMove && phase === "select") {
-      // Opponent "commits" immediately (simulated)
-      const fakeCommitment = "0x" + Array.from({ length: 16 }, () =>
-        Math.floor(Math.random() * 16).toString(16)
-      ).join("")
-      setOpponentCommitment(fakeCommitment)
-    }
-  }, [playerMove, phase])
+  const generateOpponentCommitment = useCallback((move: RpsMove) => {
+    const fakeCommitment = "0x" + Array.from({ length: 16 }, () =>
+      Math.floor(Math.random() * 16).toString(16)
+    ).join("")
+    setOpponentCommitment(fakeCommitment)
+  }, [])
 
   const handlePlay = useCallback(async () => {
     if (!playerMove || !canPlay) return
@@ -251,7 +248,12 @@ export function RpsGame({ game, onBack }: RpsGameProps) {
               key={move.id}
               type="button"
               disabled={isProcessing}
-              onClick={() => !isProcessing && setPlayerMove(move.id)}
+              onClick={() => {
+                if (!isProcessing) {
+                  setPlayerMove(move.id)
+                  if (phase === "select") generateOpponentCommitment(move.id)
+                }
+              }}
               className={cn(
                 "flex flex-col items-center justify-center py-5 px-3 rounded-xl border-2 transition-all",
                 playerMove === move.id

--- a/src/components/music/audio-player.tsx
+++ b/src/components/music/audio-player.tsx
@@ -24,12 +24,12 @@ export function AudioPlayer({ trackId, title, className }: AudioPlayerProps) {
   const isRealTrack = !trackId.startsWith("track-")
   const streamUrl = `${AUDIUS_BASE}/tracks/${trackId}/stream?app_name=${APP_NAME}`
 
-  const updateProgress = useCallback(() => {
+  const updateProgress = useCallback(function tick() {
     if (audioRef.current) {
       setProgress(audioRef.current.currentTime)
       setDuration(audioRef.current.duration || 0)
       if (!audioRef.current.paused) {
-        animRef.current = requestAnimationFrame(updateProgress)
+        animRef.current = requestAnimationFrame(tick)
       }
     }
   }, [])

--- a/tests/hooks/use-game-commitment.test.ts
+++ b/tests/hooks/use-game-commitment.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
-import { useWallet, useConnection } from "@solana/wallet-adapter-react"
+import { useWallet } from "@solana/wallet-adapter-react"
 import { useGameCommitment } from "@/hooks/use-game-commitment"
 import { createCommitmentStore, createRevealTransaction } from "@/lib/solana/commitment-store"
 import { useSolanaTransaction } from "@/hooks/use-solana-transaction"

--- a/tests/hooks/use-governance-commit.test.ts
+++ b/tests/hooks/use-governance-commit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
-import { useWallet, useConnection } from "@solana/wallet-adapter-react"
+import { useWallet } from "@solana/wallet-adapter-react"
 import { useGovernanceCommit } from "@/hooks/use-governance-commit"
 
 // Mock wallet adapter

--- a/tests/hooks/use-stealth-fund.test.ts
+++ b/tests/hooks/use-stealth-fund.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
-import { useWallet, useConnection } from "@solana/wallet-adapter-react"
+import { useWallet } from "@solana/wallet-adapter-react"
 import { useStealthFund } from "@/hooks/use-stealth-fund"
 
 // Mock wallet adapter

--- a/tests/hooks/use-stealth-tip.test.ts
+++ b/tests/hooks/use-stealth-tip.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
-import { useWallet, useConnection } from "@solana/wallet-adapter-react"
+import { useWallet } from "@solana/wallet-adapter-react"
 import { useStealthTip } from "@/hooks/use-stealth-tip"
 
 // Mock wallet adapter


### PR DESCRIPTION
## Summary

- Fix `audio-player.tsx` lint error: self-referencing variable before declaration in `requestAnimationFrame` callback — use named function expression instead
- Fix `rps-game.tsx` lint error: synchronous `setState` inside `useEffect` — replace with event-driven callback on move selection
- Remove unused `useConnection` imports from 4 test files

**Before:** 2 errors, 73 warnings
**After:** 0 errors, 70 warnings

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] All 15 affected tests pass