### PR TITLE
feat(sip.sol): integrate @sip-protocol/sns-stealth — publish UI + .sol recipient resolution

### DIFF
--- a/e2e/mainnet/sip-sol.spec.ts
+++ b/e2e/mainnet/sip-sol.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test"
+import { waitForHydration } from "../helpers/demo-mode"
+
+/**
+ * E2E coverage for `<domain>.sol` recipient resolution in the send flow.
+ *
+ * These tests hit the real Bonfida SNS RPC on mainnet so they live under
+ * `e2e/mainnet/` (90s timeout, browser-only — no test wallet required since
+ * resolution UX renders before any wallet/send action).
+ *
+ * Test domains:
+ * - `bonfida.sol` — registered on SNS but has no SIP-STEALTH record →
+ *   exercises the not-found-record warn-and-downgrade branch.
+ * - A long, manifestly unregistered .sol → exercises the not-found-domain
+ *   red-error branch.
+ *
+ * If Bonfida ever publishes a SIP-STEALTH record on `bonfida.sol`, swap the
+ * fixture to another high-profile public domain that does not.
+ */
+
+test.describe("sip.sol recipient resolution [mainnet]", () => {
+  test.setTimeout(90_000)
+
+  test("warn-and-downgrade for .sol without SIP-STEALTH record", async ({
+    page,
+  }) => {
+    await page.goto("/payments/send")
+    await waitForHydration(page)
+
+    const recipient = page.locator("#recipient")
+    await expect(recipient).toBeVisible()
+    await recipient.fill("bonfida.sol")
+
+    // Yellow warning copy
+    await expect(
+      page.getByText(/Private payment not available\./i),
+    ).toBeVisible({ timeout: 15_000 })
+    await expect(
+      page.getByText(/bonfida\.sol hasn['’]t enabled SIP-STEALTH/i),
+    ).toBeVisible()
+
+    // Both fallback buttons exist and are reachable
+    await expect(
+      page.getByRole("button", { name: /Send Public/i }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: /^Cancel$/i }),
+    ).toBeVisible()
+  })
+
+  test("Cancel button clears the recipient input", async ({ page }) => {
+    await page.goto("/payments/send")
+    await waitForHydration(page)
+
+    const recipient = page.locator("#recipient")
+    await recipient.fill("bonfida.sol")
+    await expect(
+      page.getByText(/Private payment not available\./i),
+    ).toBeVisible({ timeout: 15_000 })
+
+    await page.getByRole("button", { name: /^Cancel$/i }).click()
+
+    await expect(recipient).toHaveValue("")
+    await expect(
+      page.getByText(/Private payment not available\./i),
+    ).toHaveCount(0)
+  })
+
+  test("not-found error for unregistered .sol domain", async ({ page }) => {
+    await page.goto("/payments/send")
+    await waitForHydration(page)
+
+    const recipient = page.locator("#recipient")
+    const fake = "sip-sol-e2e-does-not-exist-xyz123.sol"
+    await recipient.fill(fake)
+
+    await expect(page.getByText(new RegExp(`${fake} not found`, "i"))).toBeVisible({
+      timeout: 15_000,
+    })
+  })
+
+  test("sip: URI still resolves synchronously (backward compat)", async ({
+    page,
+  }) => {
+    await page.goto("/payments/send")
+    await waitForHydration(page)
+
+    const recipient = page.locator("#recipient")
+    await recipient.fill(
+      "sip:solana:7x3Fh9wKpEufGCBhEkGL3tqEFBTpRNMFEP2CqAbH7mxm:2Bp4kL1CEMnP4Fd8KXk3H5bWmZFnfHvTTjw8Z9kT6yGP",
+    )
+
+    await expect(
+      page.getByText(/SIP stealth address ready/i),
+    ).toBeVisible({ timeout: 5_000 })
+    await expect(
+      page.getByText(/Resolving/i),
+    ).toHaveCount(0)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@audius/sdk": "^13.0.1",
+    "@bonfida/spl-name-service": "^3.0.21",
     "@magicblock-labs/bolt-sdk": "^0.2.4",
     "@metaplex-foundation/mpl-bubblegum": "^5.0.2",
     "@noble/ciphers": "^2.1.1",
@@ -45,6 +46,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@sip-protocol/react": "^0.1.0",
     "@sip-protocol/sdk": "0.8.1",
+    "@sip-protocol/sns-stealth": "^0.1.0",
     "@sip-protocol/types": "^0.2.2",
     "@solana/spl-governance": "^0.3.28",
     "@solana/spl-memo": "^0.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@audius/sdk':
         specifier: ^13.0.1
         version: 13.0.1(@improbable-eng/grpc-web@0.15.0(google-protobuf@3.21.4))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(google-protobuf@3.21.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@bonfida/spl-name-service':
+        specifier: ^3.0.21
+        version: 3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@magicblock-labs/bolt-sdk':
         specifier: ^0.2.4
         version: 0.2.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -48,7 +51,10 @@ importers:
         version: 0.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@sip-protocol/sdk':
         specifier: 0.8.1
-        version: 0.8.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@4.3.6))
+        version: 0.8.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
+      '@sip-protocol/sns-stealth':
+        specifier: ^0.1.0
+        version: 0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@sip-protocol/types':
         specifier: ^0.2.2
         version: 0.2.2
@@ -69,7 +75,7 @@ importers:
         version: 0.9.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
       '@solana/wallet-adapter-wallets':
         specifier: ^0.19.37
-        version: 0.19.37(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+        version: 0.19.37(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@solana/web3.js':
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -445,6 +451,16 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bonfida/sns-records@0.1.0':
+    resolution: {integrity: sha512-/viuqvsjvAUjFxzqX0L3ZntfK1S5K1Nj+j2avxq2tCXhA2Ee7Qt0gPCaQKuMv3hh8cKAEMaZ8crZHomns3UuqA==}
+    peerDependencies:
+      '@solana/web3.js': ^1.87.3
+
+  '@bonfida/spl-name-service@3.0.21':
+    resolution: {integrity: sha512-dYKZwG2ColaDUvX+ZrzcPtE6sQcNNwXywMsLit57Z+bKSEYQdIFxncrDSSzjLKcxQRFPUQObptaSEcv+ZwcMQA==}
+    peerDependencies:
+      '@solana/web3.js': ^1.98.2
 
   '@bundlr-network/client@0.8.9':
     resolution: {integrity: sha512-SJ7BAt/KhONeFQ0+nbqrw2DUWrsev6y6cmlXt+3x7fPCkw7OJwudtxV/h2nBteZd65NXjqw8yzkmLiLfZ7CCRA==}
@@ -2118,6 +2134,9 @@ packages:
   '@sip-protocol/sdk@0.8.1':
     resolution: {integrity: sha512-W6x7S9MgFhRnEIFqaMRhYSu3fgH5tv07WLvu1F78AO3OunJxEpLYknhhdJAJWLvVA6c9zq4z75tQu7wSE3FNhg==}
 
+  '@sip-protocol/sns-stealth@0.1.0':
+    resolution: {integrity: sha512-XPb7gSQf+ie7MmNXr9vpZU69UvO5/XWDqrfECel1m65UBu20F+/3ohFeD4TmowkJ4f6UHkA1HCNxMv9y6Slc4A==}
+
   '@sip-protocol/types@0.2.2':
     resolution: {integrity: sha512-FvJosQIp/dnADchEFmjdqCBlKolL4RrW15W2MPR1zlSZax9UbIR3vZjkm/j3mWewjO/bBfXii3FSxnqFlSBSkQ==}
 
@@ -2271,6 +2290,9 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs-core@2.0.0-preview.2':
+    resolution: {integrity: sha512-gLhCJXieSCrAU7acUJjbXl+IbGnqovvxQLlimztPoGgfLQ1wFYu+XJswrEVQqknZYK1pgxpxH3rZ+OKFs0ndQg==}
+
   '@solana/codecs-core@2.0.0-preview.3':
     resolution: {integrity: sha512-xQz6USSBs82lUNoVa/wwnm6wa2y2eWtGwPLUwF/NOGGpR+QH9EODijXvJ8wuC9llyqerqdC+5mrmx9C8VSMNYg==}
 
@@ -2306,6 +2328,9 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs-data-structures@2.0.0-preview.2':
+    resolution: {integrity: sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==}
+
   '@solana/codecs-data-structures@2.0.0-preview.3':
     resolution: {integrity: sha512-PfXvZCf9qDF+Dv4WG6cb4xZoY9tj117bmZWS17iKimuNSsvuFSHpzERy0mmX2hwYEAM4CnQBd/9dgx+eAeMAsg==}
 
@@ -2334,6 +2359,9 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/codecs-numbers@2.0.0-preview.2':
+    resolution: {integrity: sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==}
 
   '@solana/codecs-numbers@2.0.0-preview.3':
     resolution: {integrity: sha512-cjsHexVAj4GveDtG0+WjW121TKMbWN7AkOvGlf1qauOJgzJvX3V7KXHWuEg8wGGfRiLiXKEgh7KieQiB17EI3Q==}
@@ -2370,6 +2398,11 @@ packages:
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
+
+  '@solana/codecs-strings@2.0.0-preview.2':
+    resolution: {integrity: sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
 
   '@solana/codecs-strings@2.0.0-preview.3':
     resolution: {integrity: sha512-CUij3XgdoqbrEYncyy+kHCIXRHjqkcjiyJhf4hWVjMXM5nu2jreehhBiLFHFjlFw2U3vp1gig5QNxji8SjpQzw==}
@@ -2414,6 +2447,9 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
+  '@solana/codecs@2.0.0-preview.2':
+    resolution: {integrity: sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==}
+
   '@solana/codecs@2.0.0-preview.3':
     resolution: {integrity: sha512-uB0GMAY1VrNoJxZ9S4F1RBL57gI+8YwxnV9DD5EP5rU8iD7Wq4wbaB2IPcENyJi7rmzytIjKJg0MI6i2bBr+0w==}
 
@@ -2452,6 +2488,10 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/errors@2.0.0-preview.2':
+    resolution: {integrity: sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==}
+    hasBin: true
 
   '@solana/errors@2.0.0-preview.3':
     resolution: {integrity: sha512-IZAUMcKaV3Hn0QTfzlGmVsDaH1mVUq0uURJi+tm8K3n37cKrvXyS2GQsHtIMRaLdOVp1IbTtIc5YF3+qATlpyw==}
@@ -2636,6 +2676,9 @@ packages:
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/options@2.0.0-preview.2':
+    resolution: {integrity: sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==}
 
   '@solana/options@2.0.0-preview.3':
     resolution: {integrity: sha512-tT5O1CCJVE+rzo4VeeivYLNUL4L/2BjIeiy0MRh04lPxieiR346vUOPC1uCWGD6WqyTOOVUL0tsY4saYLmCTtA==}
@@ -3043,6 +3086,12 @@ packages:
     peerDependencies:
       '@solana/web3.js': ^1.91.6
 
+  '@solana/spl-token-group@0.0.4':
+    resolution: {integrity: sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
+
   '@solana/spl-token-group@0.0.7':
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
     engines: {node: '>=16'}
@@ -3078,6 +3127,16 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.5
+
+  '@solana/spl-token@0.4.6':
+    resolution: {integrity: sha512-1nCnUqfHVtdguFciVWaY/RKcQz1IF4b31jnKgAmjU9QVN1q7dRUkTEWJZgTYIEtsULjVnC9jRqlhgGN39WbKKA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
+
+  '@solana/spl-type-length-value@0.1.0':
+    resolution: {integrity: sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==}
+    engines: {node: '>=16'}
 
   '@solana/subscribable@2.0.0':
     resolution: {integrity: sha512-Ex7d2GnTSNVMZDU3z6nKN4agRDDgCgBDiLnmn1hmt0iFo3alr3gRAqiqa7qGouAtYh9/29pyc8tVJCijHWJPQQ==}
@@ -4940,6 +4999,12 @@ packages:
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
+  borsh@1.0.0:
+    resolution: {integrity: sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==}
+
+  borsh@2.0.0:
+    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
+
   bowser@2.13.1:
     resolution: {integrity: sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==}
 
@@ -6200,6 +6265,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphemesplit@2.6.0:
+    resolution: {integrity: sha512-rG9w2wAfkpg0DILa1pjnjNfucng3usON360shisqIMUBw/87pojcBSrHmeE4UwryAuBih7g8m1oilf5/u8EWdQ==}
+
   graphql@16.13.0:
     resolution: {integrity: sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
@@ -6391,6 +6459,10 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -7615,6 +7687,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
@@ -8513,6 +8588,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tiny-secp256k1@1.1.7:
     resolution: {integrity: sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==}
     engines: {node: '>=6.0.0'}
@@ -8727,6 +8805,9 @@ packages:
 
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unidragger@3.0.1:
     resolution: {integrity: sha512-RngbGSwBFmqGBWjkaH+yB677uzR95blSQyxq6hYbrQCejH3Mx1nm8DVOuh3M9k2fQyTstWUG5qlgCnNqV/9jVw==}
@@ -9631,6 +9712,32 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bonfida/sns-records@0.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      borsh: 1.0.0
+      bs58: 5.0.0
+      buffer: 6.0.3
+
+  '@bonfida/spl-name-service@3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bonfida/sns-records': 0.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@noble/curves': 1.9.7
+      '@scure/base': 1.2.6
+      '@solana/spl-token': 0.4.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      borsh: 2.0.0
+      buffer: 6.0.3
+      graphemesplit: 2.6.0
+      ipaddr.js: 2.4.0
+      punycode: 2.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@bundlr-network/client@0.8.9(@types/node@25.3.0)(bufferutil@4.1.0)(debug@4.4.3)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -10828,14 +10935,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))':
+  '@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
+      langsmith: 0.3.87(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -10848,39 +10955,39 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@2.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@2.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@types/json-schema': 7.0.15
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.1.5(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)':
+  '@langchain/langgraph@1.1.5(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@4.3.6)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))
-      '@langchain/langgraph-sdk': 2.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 2.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.3.6
     optionalDependencies:
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
@@ -11606,24 +11713,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit-common@1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit-controllers@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/universal-provider': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.4)
-      viem: 2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11656,12 +11763,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@4.3.6)':
+  '@reown/appkit-scaffold-ui@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-ui': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-utils': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@4.3.6)
+      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.1.0
     transitivePeerDependencies:
@@ -11693,10 +11800,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit-ui@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.1.0
       qrcode: 1.5.3
@@ -11728,16 +11835,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@4.3.6)':
+  '@reown/appkit-utils@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.7.2
       '@reown/appkit-wallet': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/universal-provider': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.4)
-      viem: 2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11777,20 +11884,20 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit@1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-common': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.7.2
-      '@reown/appkit-scaffold-ui': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@4.3.6)
-      '@reown/appkit-ui': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-utils': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@4.3.6)
+      '@reown/appkit-scaffold-ui': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
-      '@walletconnect/universal-provider': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/universal-provider': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.4)
-      viem: 2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12002,13 +12109,13 @@ snapshots:
       '@scure/base': 2.0.0
       '@sip-protocol/types': 0.2.2
 
-  '@sip-protocol/sdk@0.8.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@4.3.6))':
+  '@sip-protocol/sdk@0.8.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@aztec/bb.js': 3.0.2
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
-      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -12027,7 +12134,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.26(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      langchain: 1.2.26(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.1
       zod: 4.3.6
     optionalDependencies:
@@ -12048,6 +12155,20 @@ snapshots:
       - utf-8-validate
       - ws
       - zod-to-json-schema
+
+  '@sip-protocol/sns-stealth@0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bonfida/spl-name-service': 3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@sip-protocol/types@0.2.2': {}
 
@@ -12293,6 +12414,10 @@ snapshots:
       '@solana/errors': 2.0.0(typescript@5.9.3)
       typescript: 5.9.3
 
+  '@solana/codecs-core@2.0.0-preview.2':
+    dependencies:
+      '@solana/errors': 2.0.0-preview.2
+
   '@solana/codecs-core@2.0.0-preview.3':
     dependencies:
       '@solana/errors': 2.0.0-preview.3
@@ -12324,6 +12449,12 @@ snapshots:
       '@solana/codecs-numbers': 2.0.0(typescript@5.9.3)
       '@solana/errors': 2.0.0(typescript@5.9.3)
       typescript: 5.9.3
+
+  '@solana/codecs-data-structures@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
 
   '@solana/codecs-data-structures@2.0.0-preview.3':
     dependencies:
@@ -12358,6 +12489,11 @@ snapshots:
       '@solana/codecs-core': 2.0.0(typescript@5.9.3)
       '@solana/errors': 2.0.0(typescript@5.9.3)
       typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
 
   '@solana/codecs-numbers@2.0.0-preview.3':
     dependencies:
@@ -12396,6 +12532,13 @@ snapshots:
       '@solana/errors': 2.0.0(typescript@5.9.3)
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
+
+  '@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
+      fastestsmallesttextencoderdecoder: 1.0.22
 
   '@solana/codecs-strings@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)':
     dependencies:
@@ -12445,6 +12588,16 @@ snapshots:
       '@solana/codecs-strings': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/options': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-data-structures': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/codecs-strings': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/options': 2.0.0-preview.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
@@ -12510,6 +12663,11 @@ snapshots:
       chalk: 5.6.2
       commander: 12.1.0
       typescript: 5.9.3
+
+  '@solana/errors@2.0.0-preview.2':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
 
   '@solana/errors@2.0.0-preview.3':
     dependencies:
@@ -12735,6 +12893,11 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/options@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
 
   '@solana/options@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)':
     dependencies:
@@ -13394,6 +13557,14 @@ snapshots:
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       buffer: 6.0.3
 
+  '@solana/spl-token-group@0.0.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/spl-type-length-value': 0.1.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -13462,6 +13633,25 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
+
+  '@solana/spl-token@0.4.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token-group': 0.0.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/spl-type-length-value@0.1.0':
+    dependencies:
+      buffer: 6.0.3
 
   '@solana/subscribable@2.0.0(typescript@5.9.3)':
     dependencies:
@@ -13981,11 +14171,11 @@ snapshots:
       '@solana/wallet-standard-util': 1.1.2
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana/wallet-adapter-walletconnect@0.1.21(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@solana/wallet-adapter-walletconnect@0.1.21(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/solana-adapter': 0.0.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/solana-adapter': 0.0.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14014,7 +14204,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@solana/wallet-adapter-wallets@0.19.37(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)':
+  '@solana/wallet-adapter-wallets@0.19.37(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@solana/wallet-adapter-alpha': 0.1.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-avana': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -14050,7 +14240,7 @@ snapshots:
       '@solana/wallet-adapter-trezor': 0.1.6(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-trust': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-unsafe-burner': 0.1.11(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana/wallet-adapter-walletconnect': 0.1.21(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@solana/wallet-adapter-walletconnect': 0.1.21(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@solana/wallet-adapter-xdefi': 0.1.11(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -15387,7 +15577,7 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.0
 
-  '@walletconnect/core@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/core@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -15401,7 +15591,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       events: 3.3.0
       lodash.isequal: 4.5.0
@@ -15431,7 +15621,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/core@2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -15445,7 +15635,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -15574,16 +15764,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/sign-client@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/core': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -15610,16 +15800,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/sign-client@2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/core': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -15646,13 +15836,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/solana-adapter@0.0.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/solana-adapter@0.0.8(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit': 1.7.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/universal-provider': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -15744,7 +15934,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/universal-provider@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -15753,9 +15943,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/sign-client': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
       lodash: 4.17.23
     transitivePeerDependencies:
@@ -15784,7 +15974,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/universal-provider@2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -15793,9 +15983,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/sign-client': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))
-      '@walletconnect/utils': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -15824,7 +16014,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/utils@2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -15842,7 +16032,7 @@ snapshots:
       elliptic: 6.6.1
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15868,7 +16058,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/utils@2.19.1(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -15887,7 +16077,7 @@ snapshots:
       elliptic: 6.6.1
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -16320,10 +16510,10 @@ snapshots:
       typescript: 5.9.3
       zod: 3.21.4
 
-  abitype@1.0.8(typescript@5.9.3)(zod@4.3.6):
+  abitype@1.0.8(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
-      zod: 4.3.6
+      zod: 3.25.76
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.21.4):
     optionalDependencies:
@@ -16335,10 +16525,10 @@ snapshots:
       typescript: 5.9.3
       zod: 3.22.4
 
-  abitype@1.2.3(typescript@5.9.3)(zod@4.3.6):
+  abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
-      zod: 4.3.6
+      zod: 3.25.76
 
   abort-controller@3.0.0:
     dependencies:
@@ -16800,6 +16990,10 @@ snapshots:
       bn.js: 5.2.3
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
+
+  borsh@1.0.0: {}
+
+  borsh@2.0.0: {}
 
   bowser@2.13.1: {}
 
@@ -18376,6 +18570,11 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphemesplit@2.6.0:
+    dependencies:
+      js-base64: 3.7.8
+      unicode-trie: 2.0.0
+
   graphql@16.13.0: {}
 
   h3@1.15.5:
@@ -18619,6 +18818,8 @@ snapshots:
       loose-envify: 1.4.0
 
   ip-address@10.1.0: {}
+
+  ipaddr.js@2.4.0: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -19040,12 +19241,12 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  langchain@1.2.26(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.2.26(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/langgraph': 1.1.5(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)))
-      langsmith: 0.5.6(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
+      '@langchain/core': 0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.5(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      langsmith: 0.5.6(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
       zod: 4.3.6
     transitivePeerDependencies:
@@ -19057,7 +19258,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.3.87(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
+  langsmith@0.3.87(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -19066,9 +19267,9 @@ snapshots:
       semver: 7.7.4
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+      openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
-  langsmith@0.5.6(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
+  langsmith@0.5.6(openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 5.6.2
@@ -19077,7 +19278,7 @@ snapshots:
       semver: 7.7.4
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+      openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   language-subtag-registry@0.3.23: {}
 
@@ -20024,22 +20225,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - encoding
-    optional: true
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -20097,7 +20282,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.11.3(typescript@5.9.3)(zod@4.3.6):
+  ox@0.11.3(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -20105,21 +20290,21 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.9.3)(zod@4.3.6):
+  ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -20172,6 +20357,8 @@ snapshots:
   p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
+
+  pako@0.2.9: {}
 
   pako@2.1.0: {}
 
@@ -21337,6 +21524,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiny-inflate@1.0.3: {}
+
   tiny-secp256k1@1.1.7:
     dependencies:
       bindings: 1.5.0
@@ -21543,6 +21732,11 @@ snapshots:
 
   undici-types@7.22.0: {}
 
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+
   unidragger@3.0.1:
     dependencies:
       ev-emitter: 2.1.2
@@ -21726,15 +21920,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.6.7(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -21777,15 +21971,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+  viem@2.44.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.11.3(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.11.3(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -22103,11 +22297,6 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.1(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
-    optional: true
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/src/app/(wallet)/wallet/sip-stealth/PublishCard.tsx
+++ b/src/app/(wallet)/wallet/sip-stealth/PublishCard.tsx
@@ -33,6 +33,7 @@ interface CardStateData {
 export function PublishCard({ domainPubkey }: Props) {
   const wallet = useWallet()
   const { connection } = useConnection()
+  const getExplorerUrl = useNetworkStore((s) => s.getExplorerUrl)
 
   const [cardData, setCardData] = useState<CardStateData>({
     state: "loading",
@@ -72,13 +73,8 @@ export function PublishCard({ domainPubkey }: Props) {
             errorMessage: null,
           })
         } else {
-          // Exhaustive narrowing — NetworkError or other unknown errors surface here
-          setCardData({
-            state: "no-record",
-            domainName: fullDomain,
-            signature: null,
-            errorMessage: null,
-          })
+          const _exhaustive: never = result
+          throw new Error(`Unhandled resolve result: ${String(_exhaustive)}`)
         }
       } catch (err) {
         if (cancelled) return
@@ -128,9 +124,7 @@ export function PublishCard({ domainPubkey }: Props) {
   }, [cardData.domainName, connection, wallet])
 
   const { state, domainName, signature, errorMessage } = cardData
-  const explorerUrl = signature
-    ? useNetworkStore.getState().getExplorerUrl(signature)
-    : null
+  const explorerUrl = signature ? getExplorerUrl(signature) : null
 
   // Loading skeleton
   if (state === "loading") {
@@ -249,6 +243,11 @@ export function PublishCard({ domainPubkey }: Props) {
           type="button"
           onClick={handlePublish}
           disabled={isPublishing}
+          aria-label={
+            isPublishing
+              ? `Publishing private payments for ${domainName}`
+              : `Enable private payments for ${domainName}`
+          }
           className={cn(
             "flex-shrink-0 px-4 py-2 text-sm font-semibold rounded-xl transition-colors",
             isPublishing

--- a/src/app/(wallet)/wallet/sip-stealth/PublishCard.tsx
+++ b/src/app/(wallet)/wallet/sip-stealth/PublishCard.tsx
@@ -4,7 +4,12 @@ import { useState, useEffect, useCallback } from "react"
 import { useWallet, useConnection } from "@solana/wallet-adapter-react"
 import { PublicKey } from "@solana/web3.js"
 import { reverseLookup } from "@bonfida/spl-name-service"
-import { CheckCircle, Globe, ArrowSquareOut, Warning } from "@phosphor-icons/react"
+import {
+  CheckCircle,
+  Globe,
+  ArrowSquareOut,
+  Warning,
+} from "@phosphor-icons/react"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
 import { useNetworkStore } from "@/stores/network"
@@ -21,7 +26,13 @@ interface Props {
   domainPubkey: string
 }
 
-type CardState = "loading" | "has-record" | "no-record" | "publishing" | "published" | "error"
+type CardState =
+  | "loading"
+  | "has-record"
+  | "no-record"
+  | "publishing"
+  | "published"
+  | "error"
 
 interface CardStateData {
   state: CardState
@@ -83,22 +94,33 @@ export function PublishCard({ domainPubkey }: Props) {
           state: "error",
           domainName: null,
           signature: null,
-          errorMessage: err instanceof Error ? err.message : "Failed to load domain",
+          errorMessage:
+            err instanceof Error ? err.message : "Failed to load domain",
         })
       }
     }
 
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [domainPubkey, connection])
 
   const handlePublish = useCallback(async () => {
     if (!cardData.domainName) return
 
-    setCardData((prev) => ({ ...prev, state: "publishing", errorMessage: null }))
+    setCardData((prev) => ({
+      ...prev,
+      state: "publishing",
+      errorMessage: null,
+    }))
 
     try {
-      const { signature } = await publish(connection, cardData.domainName, wallet)
+      const { signature } = await publish(
+        connection,
+        cardData.domainName,
+        wallet
+      )
       setCardData((prev) => ({
         ...prev,
         state: "published",
@@ -170,7 +192,11 @@ export function PublishCard({ domainPubkey }: Props) {
       <div className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-5">
         <div className="flex items-center gap-3">
           <div className="w-9 h-9 rounded-full bg-sip-green-500/10 flex items-center justify-center flex-shrink-0">
-            <CheckCircle size={18} className="text-sip-green-500" weight="fill" />
+            <CheckCircle
+              size={18}
+              className="text-sip-green-500"
+              weight="fill"
+            />
           </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
@@ -191,7 +217,11 @@ export function PublishCard({ domainPubkey }: Props) {
       <div className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-5">
         <div className="flex items-center gap-3">
           <div className="w-9 h-9 rounded-full bg-sip-green-500/10 flex items-center justify-center flex-shrink-0">
-            <CheckCircle size={18} className="text-sip-green-500" weight="fill" />
+            <CheckCircle
+              size={18}
+              className="text-sip-green-500"
+              weight="fill"
+            />
           </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm font-semibold text-[var(--text-primary)] truncate">

--- a/src/app/(wallet)/wallet/sip-stealth/PublishCard.tsx
+++ b/src/app/(wallet)/wallet/sip-stealth/PublishCard.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { useWallet, useConnection } from "@solana/wallet-adapter-react"
+import { PublicKey } from "@solana/web3.js"
+import { reverseLookup } from "@bonfida/spl-name-service"
+import { CheckCircle, Globe, ArrowSquareOut, Warning } from "@phosphor-icons/react"
+import { cn } from "@/lib/utils"
+import { logger } from "@/lib/logger"
+import { useNetworkStore } from "@/stores/network"
+import {
+  resolve,
+  publish,
+  MetaAddress,
+  NotFound,
+  Malformed,
+  UserRejected,
+} from "@/lib/sns-stealth-client"
+
+interface Props {
+  domainPubkey: string
+}
+
+type CardState = "loading" | "has-record" | "no-record" | "publishing" | "published" | "error"
+
+interface CardStateData {
+  state: CardState
+  domainName: string | null
+  signature: string | null
+  errorMessage: string | null
+}
+
+export function PublishCard({ domainPubkey }: Props) {
+  const wallet = useWallet()
+  const { connection } = useConnection()
+
+  const [cardData, setCardData] = useState<CardStateData>({
+    state: "loading",
+    domainName: null,
+    signature: null,
+    errorMessage: null,
+  })
+
+  // Resolve domain name and check for existing SIP-STEALTH record on mount
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        const pk = new PublicKey(domainPubkey)
+        const bareName = await reverseLookup(connection, pk)
+        const fullDomain = `${bareName}.sol`
+
+        if (cancelled) return
+
+        const result = await resolve(connection, fullDomain)
+
+        if (cancelled) return
+
+        if (result instanceof MetaAddress) {
+          setCardData({
+            state: "has-record",
+            domainName: fullDomain,
+            signature: null,
+            errorMessage: null,
+          })
+        } else if (result instanceof NotFound || result instanceof Malformed) {
+          setCardData({
+            state: "no-record",
+            domainName: fullDomain,
+            signature: null,
+            errorMessage: null,
+          })
+        } else {
+          // Exhaustive narrowing — NetworkError or other unknown errors surface here
+          setCardData({
+            state: "no-record",
+            domainName: fullDomain,
+            signature: null,
+            errorMessage: null,
+          })
+        }
+      } catch (err) {
+        if (cancelled) return
+        logger.error("Failed to load domain card", err, "PublishCard")
+        setCardData({
+          state: "error",
+          domainName: null,
+          signature: null,
+          errorMessage: err instanceof Error ? err.message : "Failed to load domain",
+        })
+      }
+    }
+
+    load()
+    return () => { cancelled = true }
+  }, [domainPubkey, connection])
+
+  const handlePublish = useCallback(async () => {
+    if (!cardData.domainName) return
+
+    setCardData((prev) => ({ ...prev, state: "publishing", errorMessage: null }))
+
+    try {
+      const { signature } = await publish(connection, cardData.domainName, wallet)
+      setCardData((prev) => ({
+        ...prev,
+        state: "published",
+        signature,
+        errorMessage: null,
+      }))
+    } catch (err) {
+      logger.error("Failed to publish SIP-STEALTH record", err, "PublishCard")
+
+      let message = "Failed to publish record"
+      if (err instanceof UserRejected) {
+        message = "Transaction rejected"
+      } else if (err instanceof Error) {
+        message = err.message
+      }
+
+      setCardData((prev) => ({
+        ...prev,
+        state: "no-record",
+        errorMessage: message,
+      }))
+    }
+  }, [cardData.domainName, connection, wallet])
+
+  const { state, domainName, signature, errorMessage } = cardData
+  const explorerUrl = signature
+    ? useNetworkStore.getState().getExplorerUrl(signature)
+    : null
+
+  // Loading skeleton
+  if (state === "loading") {
+    return (
+      <div
+        className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-5"
+        aria-busy="true"
+        aria-label="Loading domain"
+      >
+        <div className="flex items-center gap-3">
+          <div className="w-9 h-9 rounded-full bg-[var(--surface-tertiary)] animate-pulse" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-28 rounded bg-[var(--surface-tertiary)] animate-pulse" />
+            <div className="h-3 w-48 rounded bg-[var(--surface-tertiary)] animate-pulse" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Error loading card
+  if (state === "error") {
+    return (
+      <div className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-5">
+        <div className="flex items-center gap-3">
+          <div className="w-9 h-9 rounded-full bg-red-500/10 flex items-center justify-center flex-shrink-0">
+            <Warning size={18} className="text-red-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-[var(--text-primary)] truncate">
+              {domainPubkey.slice(0, 8)}…
+            </p>
+            <p className="text-xs text-red-400 mt-0.5">{errorMessage}</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Record exists — success state (already enabled)
+  if (state === "has-record") {
+    return (
+      <div className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-5">
+        <div className="flex items-center gap-3">
+          <div className="w-9 h-9 rounded-full bg-sip-green-500/10 flex items-center justify-center flex-shrink-0">
+            <CheckCircle size={18} className="text-sip-green-500" weight="fill" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
+              {domainName}
+            </p>
+            <p className="text-xs text-sip-green-500 mt-0.5">
+              Private payments enabled
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Just published — published state
+  if (state === "published") {
+    return (
+      <div className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-5">
+        <div className="flex items-center gap-3">
+          <div className="w-9 h-9 rounded-full bg-sip-green-500/10 flex items-center justify-center flex-shrink-0">
+            <CheckCircle size={18} className="text-sip-green-500" weight="fill" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
+              {domainName}
+            </p>
+            <div className="flex items-center gap-1 mt-0.5">
+              <span className="text-xs text-sip-green-500">Published</span>
+              {explorerUrl && (
+                <>
+                  <span className="text-xs text-[var(--text-tertiary)]">—</span>
+                  <a
+                    href={explorerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-0.5 text-xs text-sip-purple-400 hover:text-sip-purple-300 transition-colors"
+                  >
+                    tx <ArrowSquareOut size={10} />
+                  </a>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // no-record / publishing — action state
+  const isPublishing = state === "publishing"
+
+  return (
+    <div className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-5">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-9 h-9 rounded-full bg-[var(--surface-tertiary)] flex items-center justify-center flex-shrink-0">
+            <Globe size={18} className="text-[var(--text-secondary)]" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
+              {domainName}
+            </p>
+            <p className="text-xs text-[var(--text-secondary)] mt-0.5">
+              No SIP stealth record
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handlePublish}
+          disabled={isPublishing}
+          className={cn(
+            "flex-shrink-0 px-4 py-2 text-sm font-semibold rounded-xl transition-colors",
+            isPublishing
+              ? "bg-sip-purple-600/50 text-white/70 cursor-not-allowed"
+              : "bg-sip-purple-600 text-white hover:bg-sip-purple-700"
+          )}
+        >
+          {isPublishing ? "Publishing…" : "Enable"}
+        </button>
+      </div>
+
+      {errorMessage && (
+        <p className="mt-3 text-xs text-red-400 flex items-center gap-1.5">
+          <Warning size={12} />
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/app/(wallet)/wallet/sip-stealth/page.tsx
+++ b/src/app/(wallet)/wallet/sip-stealth/page.tsx
@@ -29,7 +29,9 @@ export default function SipStealthPage() {
           setLoadState("idle")
         }
       })
-      return () => { cancelled = true }
+      return () => {
+        cancelled = true
+      }
     }
 
     // Defer initial state transition to avoid sync setState-in-effect lint error
@@ -49,11 +51,15 @@ export default function SipStealthPage() {
       .catch((err) => {
         if (cancelled) return
         logger.error("Failed to load .sol domains", err, "SipStealthPage")
-        setErrorMessage(err instanceof Error ? err.message : "Failed to load domains")
+        setErrorMessage(
+          err instanceof Error ? err.message : "Failed to load domains"
+        )
         setLoadState("error")
       })
 
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [publicKey, connected, connection])
 
   return (
@@ -62,7 +68,11 @@ export default function SipStealthPage() {
       <div className="mb-8">
         <div className="flex items-center gap-3 mb-3">
           <div className="w-10 h-10 rounded-xl bg-sip-purple-500/15 flex items-center justify-center">
-            <ShieldCheck size={20} className="text-sip-purple-400" weight="fill" />
+            <ShieldCheck
+              size={20}
+              className="text-sip-purple-400"
+              weight="fill"
+            />
           </div>
           <h1 className="text-2xl font-bold text-[var(--text-primary)]">
             Enable Private Payments
@@ -86,7 +96,8 @@ export default function SipStealthPage() {
             Connect your wallet
           </p>
           <p className="text-sm text-[var(--text-secondary)]">
-            Connect a wallet to see your .sol domains and enable private payments.
+            Connect a wallet to see your .sol domains and enable private
+            payments.
           </p>
         </div>
       )}
@@ -115,7 +126,9 @@ export default function SipStealthPage() {
       {/* Error loading domains */}
       {connected && loadState === "error" && (
         <div className="bg-[var(--surface-primary)] border border-red-500/20 rounded-2xl p-6 text-center">
-          <p className="text-sm text-red-400 font-medium mb-1">Failed to load domains</p>
+          <p className="text-sm text-red-400 font-medium mb-1">
+            Failed to load domains
+          </p>
           <p className="text-xs text-[var(--text-tertiary)]">{errorMessage}</p>
         </div>
       )}

--- a/src/app/(wallet)/wallet/sip-stealth/page.tsx
+++ b/src/app/(wallet)/wallet/sip-stealth/page.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useWallet, useConnection } from "@solana/wallet-adapter-react"
+import { PublicKey } from "@solana/web3.js"
+import { getAllDomains } from "@bonfida/spl-name-service"
+import { ShieldCheck, ArrowSquareOut } from "@phosphor-icons/react"
+import { logger } from "@/lib/logger"
+import { PublishCard } from "./PublishCard"
+
+type LoadState = "idle" | "loading" | "loaded" | "error"
+
+export default function SipStealthPage() {
+  const { publicKey, connected } = useWallet()
+  const { connection } = useConnection()
+
+  const [domains, setDomains] = useState<PublicKey[]>([])
+  const [loadState, setLoadState] = useState<LoadState>("idle")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!publicKey || !connected) {
+      // Deferred to avoid sync setState in effect (same pattern as send-shielded-form)
+      queueMicrotask(() => {
+        if (!cancelled) {
+          setDomains([])
+          setLoadState("idle")
+        }
+      })
+      return () => { cancelled = true }
+    }
+
+    // Defer initial state transition to avoid sync setState-in-effect lint error
+    queueMicrotask(() => {
+      if (!cancelled) {
+        setLoadState("loading")
+        setErrorMessage(null)
+      }
+    })
+
+    getAllDomains(connection, publicKey)
+      .then((pks) => {
+        if (cancelled) return
+        setDomains(pks)
+        setLoadState("loaded")
+      })
+      .catch((err) => {
+        if (cancelled) return
+        logger.error("Failed to load .sol domains", err, "SipStealthPage")
+        setErrorMessage(err instanceof Error ? err.message : "Failed to load domains")
+        setLoadState("error")
+      })
+
+    return () => { cancelled = true }
+  }, [publicKey, connected, connection])
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8 sm:py-12">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-3">
+          <div className="w-10 h-10 rounded-xl bg-sip-purple-500/15 flex items-center justify-center">
+            <ShieldCheck size={20} className="text-sip-purple-400" weight="fill" />
+          </div>
+          <h1 className="text-2xl font-bold text-[var(--text-primary)]">
+            Enable Private Payments
+          </h1>
+        </div>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
+          Publish a SIP stealth record to your{" "}
+          <span className="text-[var(--text-primary)] font-medium">.sol</span>{" "}
+          domain so others can send you private payments without revealing your
+          wallet address on-chain.
+        </p>
+      </div>
+
+      {/* Wallet not connected */}
+      {!connected && (
+        <div className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-8 text-center">
+          <div className="w-14 h-14 mx-auto mb-4 rounded-full bg-[var(--surface-tertiary)] flex items-center justify-center">
+            <ShieldCheck size={24} className="text-[var(--text-secondary)]" />
+          </div>
+          <p className="text-[var(--text-primary)] font-medium mb-1">
+            Connect your wallet
+          </p>
+          <p className="text-sm text-[var(--text-secondary)]">
+            Connect a wallet to see your .sol domains and enable private payments.
+          </p>
+        </div>
+      )}
+
+      {/* Loading */}
+      {connected && loadState === "loading" && (
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-5"
+              aria-hidden="true"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-9 h-9 rounded-full bg-[var(--surface-tertiary)] animate-pulse" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-28 rounded bg-[var(--surface-tertiary)] animate-pulse" />
+                  <div className="h-3 w-48 rounded bg-[var(--surface-tertiary)] animate-pulse" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Error loading domains */}
+      {connected && loadState === "error" && (
+        <div className="bg-[var(--surface-primary)] border border-red-500/20 rounded-2xl p-6 text-center">
+          <p className="text-sm text-red-400 font-medium mb-1">Failed to load domains</p>
+          <p className="text-xs text-[var(--text-tertiary)]">{errorMessage}</p>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {connected && loadState === "loaded" && domains.length === 0 && (
+        <div className="bg-[var(--surface-primary)] border border-[var(--border-default)] rounded-2xl p-8 text-center">
+          <div className="w-14 h-14 mx-auto mb-4 rounded-full bg-[var(--surface-tertiary)] flex items-center justify-center">
+            <ShieldCheck size={24} className="text-[var(--text-secondary)]" />
+          </div>
+          <p className="text-[var(--text-primary)] font-medium mb-1">
+            No .sol domains found
+          </p>
+          <p className="text-sm text-[var(--text-secondary)] mb-4">
+            You don&apos;t own any .sol domains. Get one at sns.id to enable
+            private payments.
+          </p>
+          <a
+            href="https://sns.id"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-xl bg-sip-purple-600 text-white hover:bg-sip-purple-700 transition-colors"
+          >
+            Get a .sol domain
+            <ArrowSquareOut size={14} />
+          </a>
+        </div>
+      )}
+
+      {/* Domain list */}
+      {connected && loadState === "loaded" && domains.length > 0 && (
+        <div className="space-y-3">
+          {domains.map((pk) => (
+            <PublishCard key={pk.toBase58()} domainPubkey={pk.toBase58()} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/payments/recipient-input.tsx
+++ b/src/components/payments/recipient-input.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
+import { useConnection } from "@solana/wallet-adapter-react"
 import {
   QrCodeIcon,
   BookOpenIcon,
@@ -8,14 +9,24 @@ import {
   XIcon,
   CameraSlashIcon,
   TrashIcon,
+  SpinnerGapIcon,
+  CheckCircleIcon,
+  WarningIcon,
+  XCircleIcon,
 } from "@phosphor-icons/react"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
+import bs58 from "bs58"
+import { resolve as snsResolve, MetaAddress, NotFound, Malformed } from "@/lib/sns-stealth-client"
+import { resolve as bonfidaResolve } from "@bonfida/spl-name-service"
+import {
+  classifyInput,
+  SIP_ADDRESS_REGEX,
+  type RecipientResolution,
+} from "./recipient-resolution"
 
-// SIP stealth address format: sip:solana:<spendingKey(base58)>:<viewingKey(base58)>
-// Base58 alphabet: [1-9A-HJ-NP-Za-km-z], 32-byte key = 32-44 base58 chars
-const SIP_ADDRESS_REGEX =
-  /^sip:solana:[1-9A-HJ-NP-Za-km-z]{32,44}:[1-9A-HJ-NP-Za-km-z]{32,44}$/
+// SNS resolution debounce delay (ms) — avoids firing on every keystroke
+const RESOLVE_DEBOUNCE_MS = 350
 
 // Saved contacts storage key
 const CONTACTS_KEY = "sip-address-book"
@@ -29,18 +40,20 @@ interface Contact {
 interface RecipientInputProps {
   value: string
   onChange: (value: string) => void
+  onResolutionChange?: (resolution: RecipientResolution) => void
   disabled?: boolean
 }
 
 export function RecipientInput({
   value,
   onChange,
+  onResolutionChange,
   disabled,
 }: RecipientInputProps) {
+  const { connection } = useConnection()
   const [touched, setTouched] = useState(false)
   const [showQRScanner, setShowQRScanner] = useState(false)
   const [showAddressBook, setShowAddressBook] = useState(false)
-  // Load contacts from localStorage using lazy initializer
   const [contacts, setContacts] = useState<Contact[]>(() => {
     if (typeof window === "undefined") return []
     try {
@@ -53,10 +66,99 @@ export function RecipientInput({
   const [newContactLabel, setNewContactLabel] = useState("")
   const [showSavePrompt, setShowSavePrompt] = useState(false)
 
-  const isValid = value === "" || SIP_ADDRESS_REGEX.test(value)
-  const showError = touched && value !== "" && !isValid
+  // Resolution state — drives all SNS-specific UX
+  const [resolution, setResolution] = useState<RecipientResolution>({ kind: "empty" })
+  // "Send Public" deferred flow: holds the resolved Solana address string
+  const [publicAddressPreview, setPublicAddressPreview] = useState<string | null>(null)
+  const [publicAddressLoading, setPublicAddressLoading] = useState(false)
 
-  // Save contacts to localStorage
+  // Stale-request guard — increments on every input change, compared inside async callback
+  const resolveGenRef = useRef(0)
+  // Debounce timer ref
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // ── Resolution effect ──────────────────────────────────────────────────────
+
+  useEffect(() => {
+    // Cancel any pending debounce
+    if (debounceRef.current !== null) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+
+    const initial = classifyInput(value)
+
+    // Non-SNS states resolve synchronously — no debounce needed
+    if (initial.kind !== "sns-resolving") {
+      resolveGenRef.current += 1
+      setResolution(initial)
+      onResolutionChange?.(initial)
+      // Clear public address preview when input changes
+      setPublicAddressPreview(null)
+      return
+    }
+
+    // SNS path: set resolving immediately, then debounce the actual network call
+    setResolution(initial)
+    onResolutionChange?.(initial)
+    setPublicAddressPreview(null)
+
+    const generation = ++resolveGenRef.current
+    const domain = initial.domain
+
+    debounceRef.current = setTimeout(async () => {
+      if (!connection) {
+        // Connection not yet available — stay in resolving state
+        return
+      }
+
+      try {
+        const result = await snsResolve(connection, domain)
+
+        if (resolveGenRef.current !== generation) return // stale — discard
+
+        let next: RecipientResolution
+
+        if (result instanceof MetaAddress) {
+          // Build sip: URI from MetaAddress
+          const uri = `sip:solana:${bs58.encode(result.spending)}:${bs58.encode(result.viewing)}`
+          next = { kind: "sns-resolved", domain, uri }
+        } else if (result instanceof NotFound) {
+          next =
+            result.subject === "domain"
+              ? { kind: "sns-not-found-domain", domain }
+              : { kind: "sns-not-found-record", domain }
+        } else if (result instanceof Malformed) {
+          next = { kind: "sns-malformed", domain, reason: result.reason }
+        } else {
+          // Unexpected result type — treat as malformed
+          next = { kind: "sns-malformed", domain, reason: "unknown" }
+        }
+
+        setResolution(next)
+        onResolutionChange?.(next)
+      } catch (err) {
+        if (resolveGenRef.current !== generation) return // stale
+
+        logger.error("SNS resolution error", err, "RecipientInput")
+        // Network/chain errors: fall back to not-found-domain (safe, shows red error)
+        const next: RecipientResolution = { kind: "sns-not-found-domain", domain }
+        setResolution(next)
+        onResolutionChange?.(next)
+      }
+    }, RESOLVE_DEBOUNCE_MS)
+
+    return () => {
+      if (debounceRef.current !== null) {
+        clearTimeout(debounceRef.current)
+        debounceRef.current = null
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, connection])
+
+  // ── Contact helpers ────────────────────────────────────────────────────────
+
   const saveContacts = useCallback((newContacts: Contact[]) => {
     try {
       localStorage.setItem(CONTACTS_KEY, JSON.stringify(newContacts))
@@ -70,17 +172,14 @@ export function RecipientInput({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       onChange(e.target.value.trim())
     },
-    [onChange]
+    [onChange],
   )
 
   const handleBlur = useCallback(() => {
     setTouched(true)
-    // Show save prompt if valid address and not already saved
     if (value && SIP_ADDRESS_REGEX.test(value)) {
       const exists = contacts.some((c) => c.address === value)
-      if (!exists) {
-        setShowSavePrompt(true)
-      }
+      if (!exists) setShowSavePrompt(true)
     }
   }, [value, contacts])
 
@@ -97,19 +196,17 @@ export function RecipientInput({
   const handleSelectContact = useCallback(
     (contact: Contact) => {
       onChange(contact.address)
-      // Update last used
       const updated = contacts.map((c) =>
-        c.address === contact.address ? { ...c, lastUsed: Date.now() } : c
+        c.address === contact.address ? { ...c, lastUsed: Date.now() } : c,
       )
       saveContacts(updated)
       setShowAddressBook(false)
     },
-    [onChange, contacts, saveContacts]
+    [onChange, contacts, saveContacts],
   )
 
   const handleSaveContact = useCallback(() => {
     if (!value || !SIP_ADDRESS_REGEX.test(value)) return
-
     const newContact: Contact = {
       address: value,
       label: newContactLabel || `Address ${contacts.length + 1}`,
@@ -124,7 +221,7 @@ export function RecipientInput({
     (address: string) => {
       saveContacts(contacts.filter((c) => c.address !== address))
     },
-    [contacts, saveContacts]
+    [contacts, saveContacts],
   )
 
   const handleQRScan = useCallback(
@@ -133,10 +230,54 @@ export function RecipientInput({
       setTouched(true)
       setShowQRScanner(false)
     },
-    [onChange]
+    [onChange],
   )
 
-  // Sort contacts by last used
+  // ── "Not-found-record" warn-and-downgrade handlers ─────────────────────────
+
+  const handleCancel = useCallback(() => {
+    onChange("")
+  }, [onChange])
+
+  const handleSendPublic = useCallback(async () => {
+    if (resolution.kind !== "sns-not-found-record") return
+    const domain = resolution.domain
+
+    setPublicAddressLoading(true)
+    setPublicAddressPreview(null)
+
+    try {
+      // Resolve the domain's SOL pointer (the public Solana address it points to)
+      const pubkey = await bonfidaResolve(connection, domain)
+      setPublicAddressPreview(pubkey.toBase58())
+    } catch (err) {
+      logger.error("Bonfida resolve error for Send Public", err, "RecipientInput")
+      setPublicAddressPreview("error")
+    } finally {
+      setPublicAddressLoading(false)
+    }
+
+    // TODO: Implement full public-send flow once the form supports raw Solana
+    // addresses as recipients. Currently only sip: URIs are supported by
+    // useSendPayment. Tracked in: sip-app#[send-public-follow-up].
+  }, [resolution, connection])
+
+  // ── Border color based on resolution ──────────────────────────────────────
+
+  const inputBorderClass = (() => {
+    if (resolution.kind === "sns-resolved" || resolution.kind === "sip-uri") {
+      return "border-sip-green-500 focus:border-sip-green-500"
+    }
+    if (
+      resolution.kind === "sns-not-found-domain" ||
+      resolution.kind === "sns-malformed" ||
+      (resolution.kind === "invalid" && touched && value !== "")
+    ) {
+      return "border-red-500 focus:border-red-500"
+    }
+    return "border-[var(--border-default)] focus:border-[var(--border-focus)]"
+  })()
+
   const sortedContacts = [...contacts].sort((a, b) => b.lastUsed - a.lastUsed)
 
   return (
@@ -145,7 +286,7 @@ export function RecipientInput({
         htmlFor="recipient"
         className="block text-sm font-medium text-[var(--text-secondary)] mb-2"
       >
-        Recipient Stealth Address
+        Recipient
       </label>
 
       <div className="relative">
@@ -156,19 +297,26 @@ export function RecipientInput({
           onChange={handleChange}
           onBlur={handleBlur}
           disabled={disabled}
-          placeholder="sip:solana:7x3Fh9w...ABC:2Bp4kL1...XYZ"
+          placeholder="alice.sol or sip:solana:7x3Fh9w…:2Bp4kL1…"
           className={cn(
             "w-full px-4 py-3 pr-28 bg-[var(--surface-secondary)] border rounded-xl font-mono text-sm transition-all",
             "focus:outline-none focus:ring-2 focus:ring-sip-purple-500/20",
-            showError
-              ? "border-red-500 focus:border-red-500"
-              : "border-[var(--border-default)] focus:border-[var(--border-focus)]",
-            disabled && "opacity-50 cursor-not-allowed"
+            inputBorderClass,
+            disabled && "opacity-50 cursor-not-allowed",
           )}
         />
 
         {/* Action Buttons */}
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
+          {/* Resolving spinner */}
+          {resolution.kind === "sns-resolving" && (
+            <SpinnerGapIcon
+              size={16}
+              className="animate-spin text-[var(--text-tertiary)]"
+              aria-hidden
+            />
+          )}
+
           {/* QR Scanner */}
           <button
             type="button"
@@ -189,7 +337,7 @@ export function RecipientInput({
               "p-2 rounded-lg transition-colors disabled:opacity-50",
               contacts.length > 0
                 ? "text-sip-purple-400 hover:bg-sip-purple-500/10"
-                : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-tertiary)]"
+                : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-tertiary)]",
             )}
             title="Address Book"
           >
@@ -214,15 +362,117 @@ export function RecipientInput({
         </div>
       </div>
 
-      {/* Error / Help text */}
-      {showError ? (
-        <p className="mt-2 text-xs text-red-500">
-          Invalid stealth address format. Expected:
-          sip:solana:&lt;spend&gt;:&lt;view&gt;
+      {/* ── Resolution feedback area ────────────────────────────────────────── */}
+
+      {resolution.kind === "sns-resolving" && (
+        <p className="mt-2 text-xs text-[var(--text-tertiary)] flex items-center gap-1.5">
+          <SpinnerGapIcon size={12} className="animate-spin" aria-hidden />
+          Resolving {resolution.domain}…
         </p>
-      ) : (
+      )}
+
+      {resolution.kind === "sns-resolved" && (
+        <p className="mt-2 text-xs text-sip-green-500 flex items-center gap-1.5">
+          <CheckCircleIcon size={12} weight="fill" aria-hidden />
+          {resolution.domain} · private payment available
+        </p>
+      )}
+
+      {resolution.kind === "sip-uri" && value !== "" && (
+        <p className="mt-2 text-xs text-sip-green-500 flex items-center gap-1.5">
+          <CheckCircleIcon size={12} weight="fill" aria-hidden />
+          SIP stealth address ready
+        </p>
+      )}
+
+      {resolution.kind === "sns-not-found-record" && (
+        <div className="mt-3 p-3 rounded-xl bg-amber-500/10 border border-amber-500/30">
+          <div className="flex items-start gap-2 mb-2">
+            <WarningIcon
+              size={16}
+              weight="fill"
+              className="text-amber-400 mt-0.5 shrink-0"
+              aria-hidden
+            />
+            <div>
+              <p className="text-xs font-medium text-amber-300">
+                Private payment not available.
+              </p>
+              <p className="text-xs text-amber-400/80 mt-0.5">
+                {resolution.domain} hasn&apos;t enabled SIP-STEALTH.
+              </p>
+            </div>
+          </div>
+
+          {/* Public address preview (shown after "Send Public" is clicked) */}
+          {publicAddressLoading && (
+            <p className="text-xs text-[var(--text-tertiary)] flex items-center gap-1.5 mt-2">
+              <SpinnerGapIcon size={12} className="animate-spin" aria-hidden />
+              Looking up public address…
+            </p>
+          )}
+          {publicAddressPreview && publicAddressPreview !== "error" && (
+            <p className="text-xs text-[var(--text-secondary)] mt-2 font-mono break-all">
+              Public address:{" "}
+              <span className="text-[var(--text-primary)]">
+                {publicAddressPreview}
+              </span>
+              <br />
+              <span className="text-[var(--text-tertiary)] not-italic font-sans">
+                Public sends via .sol are coming in a follow-up — not yet available.
+              </span>
+            </p>
+          )}
+          {publicAddressPreview === "error" && (
+            <p className="text-xs text-red-400 mt-2">
+              Could not look up public address for {resolution.domain}.
+            </p>
+          )}
+
+          <div className="flex gap-2 mt-3">
+            <button
+              type="button"
+              onClick={handleSendPublic}
+              disabled={publicAddressLoading}
+              className="px-3 py-1.5 text-xs font-medium bg-amber-500/20 text-amber-300 border border-amber-500/30 rounded-lg hover:bg-amber-500/30 transition-colors disabled:opacity-50"
+            >
+              Send Public
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] border border-[var(--border-default)] rounded-lg hover:bg-[var(--surface-secondary)] transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {resolution.kind === "sns-not-found-domain" && (
+        <p className="mt-2 text-xs text-red-500 flex items-center gap-1.5">
+          <XCircleIcon size={12} weight="fill" aria-hidden />
+          {resolution.domain} not found
+        </p>
+      )}
+
+      {resolution.kind === "sns-malformed" && (
+        <p className="mt-2 text-xs text-red-500 flex items-center gap-1.5">
+          <XCircleIcon size={12} weight="fill" aria-hidden />
+          {resolution.domain}&apos;s privacy record is invalid ({resolution.reason})
+        </p>
+      )}
+
+      {resolution.kind === "invalid" && touched && value !== "" && (
+        <p className="mt-2 text-xs text-red-500">
+          Invalid format. Use a .sol domain or sip:solana:&lt;spend&gt;:&lt;view&gt;
+        </p>
+      )}
+
+      {/* Empty / pristine help text */}
+      {(resolution.kind === "empty" || (resolution.kind === "sip-uri" && value === "")) && (
         <p className="mt-2 text-xs text-[var(--text-tertiary)]">
-          Enter the recipient&apos;s SIP stealth meta-address
+          Enter a .sol domain or SIP stealth meta-address
         </p>
       )}
 
@@ -279,7 +529,8 @@ export function RecipientInput({
   )
 }
 
-// QR Scanner Modal
+// ── QR Scanner Modal ───────────────────────────────────────────────────────────
+
 interface QRScannerModalProps {
   onScan: (value: string) => void
   onClose: () => void
@@ -287,7 +538,6 @@ interface QRScannerModalProps {
 
 function QRScannerModal({ onScan, onClose }: QRScannerModalProps) {
   const [manualInput, setManualInput] = useState("")
-  // Check camera availability using lazy initializer
   const [cameraError] = useState<string | null>(() => {
     if (typeof window === "undefined") return null
     if (!navigator.mediaDevices?.getUserMedia) {
@@ -329,16 +579,11 @@ function QRScannerModal({ onScan, onClose }: QRScannerModalProps) {
                 size={48}
                 className="mx-auto mb-3 text-[var(--text-tertiary)]"
               />
-              <p className="text-sm text-[var(--text-secondary)]">
-                {cameraError}
-              </p>
+              <p className="text-sm text-[var(--text-secondary)]">{cameraError}</p>
             </div>
           ) : (
             <div className="text-center px-6">
-              <QrCodeIcon
-                size={64}
-                className="mx-auto mb-4 text-sip-purple-400"
-              />
+              <QrCodeIcon size={64} className="mx-auto mb-4 text-sip-purple-400" />
               <p className="text-sm text-[var(--text-secondary)]">
                 Point your camera at a SIP address QR code
               </p>
@@ -357,7 +602,7 @@ function QRScannerModal({ onScan, onClose }: QRScannerModalProps) {
               type="text"
               value={manualInput}
               onChange={(e) => setManualInput(e.target.value)}
-              placeholder="sip:solana:..."
+              placeholder="sip:solana:... or alice.sol"
               className="flex-1 px-3 py-2 text-xs font-mono rounded-lg bg-[var(--surface-secondary)] border border-[var(--border-default)] focus:outline-none focus:border-sip-purple-500"
             />
             <button
@@ -375,7 +620,8 @@ function QRScannerModal({ onScan, onClose }: QRScannerModalProps) {
   )
 }
 
-// Address Book Modal
+// ── Address Book Modal ─────────────────────────────────────────────────────────
+
 interface AddressBookModalProps {
   contacts: Contact[]
   onSelect: (contact: Contact) => void
@@ -479,6 +725,17 @@ function AddressBookModal({
   )
 }
 
+/**
+ * Validate a raw recipient string.
+ *
+ * Returns true only for exact sip:solana URI format.
+ * SNS .sol domains are resolved asynchronously via RecipientInput's internal
+ * state machine — use `onResolutionChange` + `isReadyToSend()` from
+ * `recipient-resolution.ts` for SNS-aware validation.
+ *
+ * @deprecated Prefer the `onResolutionChange` + `isReadyToSend` pattern.
+ *   Kept for backward compatibility with callers that only need sip: URI check.
+ */
 export function validateRecipient(value: string): boolean {
   return SIP_ADDRESS_REGEX.test(value)
 }

--- a/src/components/payments/recipient-input.tsx
+++ b/src/components/payments/recipient-input.tsx
@@ -76,10 +76,18 @@ export function RecipientInput({
   const resolveGenRef = useRef(0)
   // Debounce timer ref
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Unmount guard — set true in cleanup, checked across awaits to prevent
+  // setState on an unmounted component when a resolve settles late
+  const unmountedRef = useRef(false)
 
   // ── Resolution effect ──────────────────────────────────────────────────────
 
   useEffect(() => {
+    // Re-arm unmount flag — cleanup will flip it true; if a fresh effect runs
+    // (value/connection changed), the previous run's async sees the new state
+    // via the generation counter, not via unmountedRef.
+    unmountedRef.current = false
+
     // Cancel any pending debounce
     if (debounceRef.current !== null) {
       clearTimeout(debounceRef.current)
@@ -107,6 +115,7 @@ export function RecipientInput({
     const domain = initial.domain
 
     debounceRef.current = setTimeout(async () => {
+      if (unmountedRef.current) return
       if (!connection) {
         // Connection not yet available — stay in resolving state
         return
@@ -115,6 +124,7 @@ export function RecipientInput({
       try {
         const result = await snsResolve(connection, domain)
 
+        if (unmountedRef.current) return // unmounted during await
         if (resolveGenRef.current !== generation) return // stale — discard
 
         let next: RecipientResolution
@@ -138,6 +148,7 @@ export function RecipientInput({
         setResolution(next)
         onResolutionChange?.(next)
       } catch (err) {
+        if (unmountedRef.current) return // unmounted during await
         if (resolveGenRef.current !== generation) return // stale
 
         logger.error("SNS resolution error", err, "RecipientInput")
@@ -149,11 +160,16 @@ export function RecipientInput({
     }, RESOLVE_DEBOUNCE_MS)
 
     return () => {
+      unmountedRef.current = true
       if (debounceRef.current !== null) {
         clearTimeout(debounceRef.current)
         debounceRef.current = null
       }
     }
+  // onResolutionChange intentionally omitted from deps: callers MUST pass a
+  // stable reference (useState setter or useCallback). Adding it here would
+  // re-run the effect on every parent render if a caller creates a new
+  // function reference each cycle, defeating debounce entirely.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, connection])
 
@@ -364,6 +380,13 @@ export function RecipientInput({
 
       {/* ── Resolution feedback area ────────────────────────────────────────── */}
 
+      {/*
+        aria-live: SR users typing into the input get state changes announced
+        without having to navigate to this region. Polite (not assertive) so
+        the resolving spinner doesn't interrupt rapid typing.
+      */}
+      <div aria-live="polite" aria-atomic="true">
+
       {resolution.kind === "sns-resolving" && (
         <p className="mt-2 text-xs text-[var(--text-tertiary)] flex items-center gap-1.5">
           <SpinnerGapIcon size={12} className="animate-spin" aria-hidden />
@@ -470,11 +493,14 @@ export function RecipientInput({
       )}
 
       {/* Empty / pristine help text */}
-      {(resolution.kind === "empty" || (resolution.kind === "sip-uri" && value === "")) && (
+      {resolution.kind === "empty" && (
         <p className="mt-2 text-xs text-[var(--text-tertiary)]">
           Enter a .sol domain or SIP stealth meta-address
         </p>
       )}
+
+      </div>
+      {/* /aria-live resolution feedback area */}
 
       {/* Save to Address Book Prompt */}
       {showSavePrompt && (

--- a/src/components/payments/recipient-input.tsx
+++ b/src/components/payments/recipient-input.tsx
@@ -17,7 +17,12 @@ import {
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
 import bs58 from "bs58"
-import { resolve as snsResolve, MetaAddress, NotFound, Malformed } from "@/lib/sns-stealth-client"
+import {
+  resolve as snsResolve,
+  MetaAddress,
+  NotFound,
+  Malformed,
+} from "@/lib/sns-stealth-client"
 import { resolve as bonfidaResolve } from "@bonfida/spl-name-service"
 import {
   classifyInput,
@@ -67,9 +72,13 @@ export function RecipientInput({
   const [showSavePrompt, setShowSavePrompt] = useState(false)
 
   // Resolution state — drives all SNS-specific UX
-  const [resolution, setResolution] = useState<RecipientResolution>({ kind: "empty" })
+  const [resolution, setResolution] = useState<RecipientResolution>({
+    kind: "empty",
+  })
   // "Send Public" deferred flow: holds the resolved Solana address string
-  const [publicAddressPreview, setPublicAddressPreview] = useState<string | null>(null)
+  const [publicAddressPreview, setPublicAddressPreview] = useState<
+    string | null
+  >(null)
   const [publicAddressLoading, setPublicAddressLoading] = useState(false)
 
   // Stale-request guard — increments on every input change, compared inside async callback
@@ -153,7 +162,10 @@ export function RecipientInput({
 
         logger.error("SNS resolution error", err, "RecipientInput")
         // Network/chain errors: fall back to not-found-domain (safe, shows red error)
-        const next: RecipientResolution = { kind: "sns-not-found-domain", domain }
+        const next: RecipientResolution = {
+          kind: "sns-not-found-domain",
+          domain,
+        }
         setResolution(next)
         onResolutionChange?.(next)
       }
@@ -166,11 +178,11 @@ export function RecipientInput({
         debounceRef.current = null
       }
     }
-  // onResolutionChange intentionally omitted from deps: callers MUST pass a
-  // stable reference (useState setter or useCallback). Adding it here would
-  // re-run the effect on every parent render if a caller creates a new
-  // function reference each cycle, defeating debounce entirely.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // onResolutionChange intentionally omitted from deps: callers MUST pass a
+    // stable reference (useState setter or useCallback). Adding it here would
+    // re-run the effect on every parent render if a caller creates a new
+    // function reference each cycle, defeating debounce entirely.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, connection])
 
   // ── Contact helpers ────────────────────────────────────────────────────────
@@ -188,7 +200,7 @@ export function RecipientInput({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       onChange(e.target.value.trim())
     },
-    [onChange],
+    [onChange]
   )
 
   const handleBlur = useCallback(() => {
@@ -213,12 +225,12 @@ export function RecipientInput({
     (contact: Contact) => {
       onChange(contact.address)
       const updated = contacts.map((c) =>
-        c.address === contact.address ? { ...c, lastUsed: Date.now() } : c,
+        c.address === contact.address ? { ...c, lastUsed: Date.now() } : c
       )
       saveContacts(updated)
       setShowAddressBook(false)
     },
-    [onChange, contacts, saveContacts],
+    [onChange, contacts, saveContacts]
   )
 
   const handleSaveContact = useCallback(() => {
@@ -237,7 +249,7 @@ export function RecipientInput({
     (address: string) => {
       saveContacts(contacts.filter((c) => c.address !== address))
     },
-    [contacts, saveContacts],
+    [contacts, saveContacts]
   )
 
   const handleQRScan = useCallback(
@@ -246,7 +258,7 @@ export function RecipientInput({
       setTouched(true)
       setShowQRScanner(false)
     },
-    [onChange],
+    [onChange]
   )
 
   // ── "Not-found-record" warn-and-downgrade handlers ─────────────────────────
@@ -267,7 +279,11 @@ export function RecipientInput({
       const pubkey = await bonfidaResolve(connection, domain)
       setPublicAddressPreview(pubkey.toBase58())
     } catch (err) {
-      logger.error("Bonfida resolve error for Send Public", err, "RecipientInput")
+      logger.error(
+        "Bonfida resolve error for Send Public",
+        err,
+        "RecipientInput"
+      )
       setPublicAddressPreview("error")
     } finally {
       setPublicAddressLoading(false)
@@ -318,7 +334,7 @@ export function RecipientInput({
             "w-full px-4 py-3 pr-28 bg-[var(--surface-secondary)] border rounded-xl font-mono text-sm transition-all",
             "focus:outline-none focus:ring-2 focus:ring-sip-purple-500/20",
             inputBorderClass,
-            disabled && "opacity-50 cursor-not-allowed",
+            disabled && "opacity-50 cursor-not-allowed"
           )}
         />
 
@@ -353,7 +369,7 @@ export function RecipientInput({
               "p-2 rounded-lg transition-colors disabled:opacity-50",
               contacts.length > 0
                 ? "text-sip-purple-400 hover:bg-sip-purple-500/10"
-                : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-tertiary)]",
+                : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-tertiary)]"
             )}
             title="Address Book"
           >
@@ -386,119 +402,124 @@ export function RecipientInput({
         the resolving spinner doesn't interrupt rapid typing.
       */}
       <div aria-live="polite" aria-atomic="true">
+        {resolution.kind === "sns-resolving" && (
+          <p className="mt-2 text-xs text-[var(--text-tertiary)] flex items-center gap-1.5">
+            <SpinnerGapIcon size={12} className="animate-spin" aria-hidden />
+            Resolving {resolution.domain}…
+          </p>
+        )}
 
-      {resolution.kind === "sns-resolving" && (
-        <p className="mt-2 text-xs text-[var(--text-tertiary)] flex items-center gap-1.5">
-          <SpinnerGapIcon size={12} className="animate-spin" aria-hidden />
-          Resolving {resolution.domain}…
-        </p>
-      )}
+        {resolution.kind === "sns-resolved" && (
+          <p className="mt-2 text-xs text-sip-green-500 flex items-center gap-1.5">
+            <CheckCircleIcon size={12} weight="fill" aria-hidden />
+            {resolution.domain} · private payment available
+          </p>
+        )}
 
-      {resolution.kind === "sns-resolved" && (
-        <p className="mt-2 text-xs text-sip-green-500 flex items-center gap-1.5">
-          <CheckCircleIcon size={12} weight="fill" aria-hidden />
-          {resolution.domain} · private payment available
-        </p>
-      )}
+        {resolution.kind === "sip-uri" && value !== "" && (
+          <p className="mt-2 text-xs text-sip-green-500 flex items-center gap-1.5">
+            <CheckCircleIcon size={12} weight="fill" aria-hidden />
+            SIP stealth address ready
+          </p>
+        )}
 
-      {resolution.kind === "sip-uri" && value !== "" && (
-        <p className="mt-2 text-xs text-sip-green-500 flex items-center gap-1.5">
-          <CheckCircleIcon size={12} weight="fill" aria-hidden />
-          SIP stealth address ready
-        </p>
-      )}
+        {resolution.kind === "sns-not-found-record" && (
+          <div className="mt-3 p-3 rounded-xl bg-amber-500/10 border border-amber-500/30">
+            <div className="flex items-start gap-2 mb-2">
+              <WarningIcon
+                size={16}
+                weight="fill"
+                className="text-amber-400 mt-0.5 shrink-0"
+                aria-hidden
+              />
+              <div>
+                <p className="text-xs font-medium text-amber-300">
+                  Private payment not available.
+                </p>
+                <p className="text-xs text-amber-400/80 mt-0.5">
+                  {resolution.domain} hasn&apos;t enabled SIP-STEALTH.
+                </p>
+              </div>
+            </div>
 
-      {resolution.kind === "sns-not-found-record" && (
-        <div className="mt-3 p-3 rounded-xl bg-amber-500/10 border border-amber-500/30">
-          <div className="flex items-start gap-2 mb-2">
-            <WarningIcon
-              size={16}
-              weight="fill"
-              className="text-amber-400 mt-0.5 shrink-0"
-              aria-hidden
-            />
-            <div>
-              <p className="text-xs font-medium text-amber-300">
-                Private payment not available.
+            {/* Public address preview (shown after "Send Public" is clicked) */}
+            {publicAddressLoading && (
+              <p className="text-xs text-[var(--text-tertiary)] flex items-center gap-1.5 mt-2">
+                <SpinnerGapIcon
+                  size={12}
+                  className="animate-spin"
+                  aria-hidden
+                />
+                Looking up public address…
               </p>
-              <p className="text-xs text-amber-400/80 mt-0.5">
-                {resolution.domain} hasn&apos;t enabled SIP-STEALTH.
+            )}
+            {publicAddressPreview && publicAddressPreview !== "error" && (
+              <p className="text-xs text-[var(--text-secondary)] mt-2 font-mono break-all">
+                Public address:{" "}
+                <span className="text-[var(--text-primary)]">
+                  {publicAddressPreview}
+                </span>
+                <br />
+                <span className="text-[var(--text-tertiary)] not-italic font-sans">
+                  Public sends via .sol are coming in a follow-up — not yet
+                  available.
+                </span>
               </p>
+            )}
+            {publicAddressPreview === "error" && (
+              <p className="text-xs text-red-400 mt-2">
+                Could not look up public address for {resolution.domain}.
+              </p>
+            )}
+
+            <div className="flex gap-2 mt-3">
+              <button
+                type="button"
+                onClick={handleSendPublic}
+                disabled={publicAddressLoading}
+                className="px-3 py-1.5 text-xs font-medium bg-amber-500/20 text-amber-300 border border-amber-500/30 rounded-lg hover:bg-amber-500/30 transition-colors disabled:opacity-50"
+              >
+                Send Public
+              </button>
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] border border-[var(--border-default)] rounded-lg hover:bg-[var(--surface-secondary)] transition-colors"
+              >
+                Cancel
+              </button>
             </div>
           </div>
+        )}
 
-          {/* Public address preview (shown after "Send Public" is clicked) */}
-          {publicAddressLoading && (
-            <p className="text-xs text-[var(--text-tertiary)] flex items-center gap-1.5 mt-2">
-              <SpinnerGapIcon size={12} className="animate-spin" aria-hidden />
-              Looking up public address…
-            </p>
-          )}
-          {publicAddressPreview && publicAddressPreview !== "error" && (
-            <p className="text-xs text-[var(--text-secondary)] mt-2 font-mono break-all">
-              Public address:{" "}
-              <span className="text-[var(--text-primary)]">
-                {publicAddressPreview}
-              </span>
-              <br />
-              <span className="text-[var(--text-tertiary)] not-italic font-sans">
-                Public sends via .sol are coming in a follow-up — not yet available.
-              </span>
-            </p>
-          )}
-          {publicAddressPreview === "error" && (
-            <p className="text-xs text-red-400 mt-2">
-              Could not look up public address for {resolution.domain}.
-            </p>
-          )}
+        {resolution.kind === "sns-not-found-domain" && (
+          <p className="mt-2 text-xs text-red-500 flex items-center gap-1.5">
+            <XCircleIcon size={12} weight="fill" aria-hidden />
+            {resolution.domain} not found
+          </p>
+        )}
 
-          <div className="flex gap-2 mt-3">
-            <button
-              type="button"
-              onClick={handleSendPublic}
-              disabled={publicAddressLoading}
-              className="px-3 py-1.5 text-xs font-medium bg-amber-500/20 text-amber-300 border border-amber-500/30 rounded-lg hover:bg-amber-500/30 transition-colors disabled:opacity-50"
-            >
-              Send Public
-            </button>
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] border border-[var(--border-default)] rounded-lg hover:bg-[var(--surface-secondary)] transition-colors"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
+        {resolution.kind === "sns-malformed" && (
+          <p className="mt-2 text-xs text-red-500 flex items-center gap-1.5">
+            <XCircleIcon size={12} weight="fill" aria-hidden />
+            {resolution.domain}&apos;s privacy record is invalid (
+            {resolution.reason})
+          </p>
+        )}
 
-      {resolution.kind === "sns-not-found-domain" && (
-        <p className="mt-2 text-xs text-red-500 flex items-center gap-1.5">
-          <XCircleIcon size={12} weight="fill" aria-hidden />
-          {resolution.domain} not found
-        </p>
-      )}
+        {resolution.kind === "invalid" && touched && value !== "" && (
+          <p className="mt-2 text-xs text-red-500">
+            Invalid format. Use a .sol domain or
+            sip:solana:&lt;spend&gt;:&lt;view&gt;
+          </p>
+        )}
 
-      {resolution.kind === "sns-malformed" && (
-        <p className="mt-2 text-xs text-red-500 flex items-center gap-1.5">
-          <XCircleIcon size={12} weight="fill" aria-hidden />
-          {resolution.domain}&apos;s privacy record is invalid ({resolution.reason})
-        </p>
-      )}
-
-      {resolution.kind === "invalid" && touched && value !== "" && (
-        <p className="mt-2 text-xs text-red-500">
-          Invalid format. Use a .sol domain or sip:solana:&lt;spend&gt;:&lt;view&gt;
-        </p>
-      )}
-
-      {/* Empty / pristine help text */}
-      {resolution.kind === "empty" && (
-        <p className="mt-2 text-xs text-[var(--text-tertiary)]">
-          Enter a .sol domain or SIP stealth meta-address
-        </p>
-      )}
-
+        {/* Empty / pristine help text */}
+        {resolution.kind === "empty" && (
+          <p className="mt-2 text-xs text-[var(--text-tertiary)]">
+            Enter a .sol domain or SIP stealth meta-address
+          </p>
+        )}
       </div>
       {/* /aria-live resolution feedback area */}
 
@@ -605,11 +626,16 @@ function QRScannerModal({ onScan, onClose }: QRScannerModalProps) {
                 size={48}
                 className="mx-auto mb-3 text-[var(--text-tertiary)]"
               />
-              <p className="text-sm text-[var(--text-secondary)]">{cameraError}</p>
+              <p className="text-sm text-[var(--text-secondary)]">
+                {cameraError}
+              </p>
             </div>
           ) : (
             <div className="text-center px-6">
-              <QrCodeIcon size={64} className="mx-auto mb-4 text-sip-purple-400" />
+              <QrCodeIcon
+                size={64}
+                className="mx-auto mb-4 text-sip-purple-400"
+              />
               <p className="text-sm text-[var(--text-secondary)]">
                 Point your camera at a SIP address QR code
               </p>

--- a/src/components/payments/recipient-resolution.ts
+++ b/src/components/payments/recipient-resolution.ts
@@ -73,7 +73,7 @@ export type RecipientResolution =
 
 /** Return true when the resolution represents a ready-to-send state. */
 export function isReadyToSend(
-  r: RecipientResolution,
+  r: RecipientResolution
 ): r is RSipUri | RSnsResolved {
   return r.kind === "sip-uri" || r.kind === "sns-resolved"
 }

--- a/src/components/payments/recipient-resolution.ts
+++ b/src/components/payments/recipient-resolution.ts
@@ -1,0 +1,96 @@
+/**
+ * Types and pure helpers for the recipient resolution state machine.
+ *
+ * Kept separate so both RecipientInput (UI) and tests can import without
+ * pulling in React or async logic.
+ */
+
+// ── Regex constants ───────────────────────────────────────────────────────────
+
+/** SIP meta-address: sip:solana:<spend(base58)>:<view(base58)> */
+export const SIP_ADDRESS_REGEX =
+  /^sip:solana:[1-9A-HJ-NP-Za-km-z]{32,44}:[1-9A-HJ-NP-Za-km-z]{32,44}$/
+
+/**
+ * SNS domain: any number of labels (alphanumeric + hyphen) separated by dots,
+ * ending in .sol (case-insensitive).
+ */
+export const SNS_DOMAIN_REGEX = /^[a-z0-9-]+(\.[a-z0-9-]+)*\.sol$/i
+
+// ── Resolution state tagged union ─────────────────────────────────────────────
+
+/** The recipient input has been cleared. */
+export type REmpty = { kind: "empty" }
+
+/** A valid sip:solana:… URI — ready to send. */
+export type RSipUri = { kind: "sip-uri"; uri: string }
+
+/** A .sol domain is being resolved over the network. */
+export type RSnsResolving = { kind: "sns-resolving"; domain: string }
+
+/**
+ * SIP-STEALTH record found for the domain — ready to send.
+ * `uri` is the constructed sip:solana:… string.
+ */
+export type RSnsResolved = { kind: "sns-resolved"; domain: string; uri: string }
+
+/**
+ * Domain exists but has no SIP-STEALTH record.
+ * Show warn-and-downgrade UX.
+ */
+export type RSnsNotFoundRecord = {
+  kind: "sns-not-found-record"
+  domain: string
+}
+
+/** Domain not registered on SNS. Red error. */
+export type RSnsNotFoundDomain = {
+  kind: "sns-not-found-domain"
+  domain: string
+}
+
+/** Domain exists but the SIP-STEALTH record is malformed. Red error. */
+export type RSnsmalformed = {
+  kind: "sns-malformed"
+  domain: string
+  reason: string
+}
+
+/** Input matches neither a sip: URI nor a .sol domain. Red error. */
+export type RInvalid = { kind: "invalid"; input: string }
+
+export type RecipientResolution =
+  | REmpty
+  | RSipUri
+  | RSnsResolving
+  | RSnsResolved
+  | RSnsNotFoundRecord
+  | RSnsNotFoundDomain
+  | RSnsmalformed
+  | RInvalid
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/** Return true when the resolution represents a ready-to-send state. */
+export function isReadyToSend(
+  r: RecipientResolution,
+): r is RSipUri | RSnsResolved {
+  return r.kind === "sip-uri" || r.kind === "sns-resolved"
+}
+
+/** Extract the target sip: URI from a ready resolution (or null). */
+export function targetUri(r: RecipientResolution): string | null {
+  if (r.kind === "sip-uri") return r.uri
+  if (r.kind === "sns-resolved") return r.uri
+  return null
+}
+
+/** Classify a raw input string into initial resolution state (no I/O). */
+export function classifyInput(raw: string): RecipientResolution {
+  const trimmed = raw.trim().replace(/\.$/, "") // strip trailing dot
+  if (trimmed === "") return { kind: "empty" }
+  if (SIP_ADDRESS_REGEX.test(trimmed)) return { kind: "sip-uri", uri: trimmed }
+  if (SNS_DOMAIN_REGEX.test(trimmed))
+    return { kind: "sns-resolving", domain: trimmed.toLowerCase() }
+  return { kind: "invalid", input: trimmed }
+}

--- a/src/components/payments/recipient-resolution.ts
+++ b/src/components/payments/recipient-resolution.ts
@@ -50,7 +50,7 @@ export type RSnsNotFoundDomain = {
 }
 
 /** Domain exists but the SIP-STEALTH record is malformed. Red error. */
-export type RSnsmalformed = {
+export type RSnsMalformed = {
   kind: "sns-malformed"
   domain: string
   reason: string
@@ -66,7 +66,7 @@ export type RecipientResolution =
   | RSnsResolved
   | RSnsNotFoundRecord
   | RSnsNotFoundDomain
-  | RSnsmalformed
+  | RSnsMalformed
   | RInvalid
 
 // ── Pure helpers ──────────────────────────────────────────────────────────────

--- a/src/components/payments/send-shielded-form.tsx
+++ b/src/components/payments/send-shielded-form.tsx
@@ -6,7 +6,7 @@ import { useDemoModeStore } from "@/stores/demo-mode"
 import { DemoBanner } from "@/components/ui/demo-banner"
 import { LAMPORTS_PER_SOL } from "@solana/web3.js"
 import type { ViewingKey } from "@sip-protocol/types"
-import { RecipientInput, validateRecipient } from "./recipient-input"
+import { RecipientInput } from "./recipient-input"
 import { AmountInput, type Token } from "./amount-input"
 import { PrivacyToggle, type PrivacyLevel } from "./privacy-toggle"
 import { TransactionStatus } from "./transaction-status"
@@ -15,6 +15,11 @@ import { useSendPayment } from "@/hooks/use-send-payment"
 import { useViewingKeyStorage } from "@/hooks/use-viewing-key-storage"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
+import {
+  isReadyToSend,
+  targetUri,
+  type RecipientResolution,
+} from "./recipient-resolution"
 
 export function SendShieldedForm() {
   const { publicKey, connected } = useWallet()
@@ -26,6 +31,8 @@ export function SendShieldedForm() {
 
   // Form state
   const [recipient, setRecipient] = useState("")
+  // Resolution state from RecipientInput — drives submit gate + target URI
+  const [resolution, setResolution] = useState<RecipientResolution>({ kind: "empty" })
   const [amount, setAmount] = useState("")
   const [token, setToken] = useState<Token>("SOL")
   const [privacyLevel, setPrivacyLevel] = useState<PrivacyLevel>("shielded")
@@ -62,8 +69,9 @@ export function SendShieldedForm() {
     }
   }, [publicKey, connection])
 
-  // Validation
-  const isValidRecipient = recipient !== "" && validateRecipient(recipient)
+  // Validation — recipient is ready when the resolution machine reaches a
+  // send-capable state (sip-uri or sns-resolved)
+  const isValidRecipient = isReadyToSend(resolution)
   const numericAmount = parseFloat(amount) || 0
   const isValidAmount =
     numericAmount > 0 && (balance === undefined || numericAmount <= balance)
@@ -78,6 +86,13 @@ export function SendShieldedForm() {
       e.preventDefault()
       if (!canSubmit) return
 
+      // Extract the resolved sip: URI to pass to the payment hook
+      const resolvedUri = targetUri(resolution)
+      if (!resolvedUri) {
+        logger.error("Submit called with no resolved URI", undefined, "SendShieldedForm")
+        return
+      }
+
       // For compliant mode, require viewing key
       if (privacyLevel === "compliant" && !viewingKey) {
         logger.error(
@@ -89,7 +104,7 @@ export function SendShieldedForm() {
       }
 
       const result = await send({
-        recipient,
+        recipient: resolvedUri,
         amount,
         token,
         privacyLevel,
@@ -104,7 +119,7 @@ export function SendShieldedForm() {
     [
       canSubmit,
       send,
-      recipient,
+      resolution,
       amount,
       token,
       privacyLevel,
@@ -116,6 +131,7 @@ export function SendShieldedForm() {
   const handleReset = useCallback(() => {
     reset()
     setRecipient("")
+    setResolution({ kind: "empty" })
     setAmount("")
     setPrivacyLevel("shielded")
     setViewingKey(null)
@@ -172,6 +188,7 @@ export function SendShieldedForm() {
         <RecipientInput
           value={recipient}
           onChange={setRecipient}
+          onResolutionChange={setResolution}
           disabled={status === "pending"}
         />
       </div>

--- a/src/components/payments/send-shielded-form.tsx
+++ b/src/components/payments/send-shielded-form.tsx
@@ -32,7 +32,9 @@ export function SendShieldedForm() {
   // Form state
   const [recipient, setRecipient] = useState("")
   // Resolution state from RecipientInput — drives submit gate + target URI
-  const [resolution, setResolution] = useState<RecipientResolution>({ kind: "empty" })
+  const [resolution, setResolution] = useState<RecipientResolution>({
+    kind: "empty",
+  })
   const [amount, setAmount] = useState("")
   const [token, setToken] = useState<Token>("SOL")
   const [privacyLevel, setPrivacyLevel] = useState<PrivacyLevel>("shielded")
@@ -89,7 +91,11 @@ export function SendShieldedForm() {
       // Extract the resolved sip: URI to pass to the payment hook
       const resolvedUri = targetUri(resolution)
       if (!resolvedUri) {
-        logger.error("Submit called with no resolved URI", undefined, "SendShieldedForm")
+        logger.error(
+          "Submit called with no resolved URI",
+          undefined,
+          "SendShieldedForm"
+        )
         return
       }
 

--- a/src/lib/sns-stealth-client.ts
+++ b/src/lib/sns-stealth-client.ts
@@ -1,0 +1,63 @@
+"use client"
+
+import type { Connection } from "@solana/web3.js"
+import {
+  resolveSIPStealth,
+  buildPublishTx,
+  deriveStealthKeys,
+  invalidateCache,
+  MetaAddress,
+  Malformed,
+  NetworkError,
+  NotFound,
+  OnChainError,
+  UserRejected,
+  type ResolveResult,
+} from "@sip-protocol/sns-stealth"
+import type { WalletContextState } from "@solana/wallet-adapter-react"
+
+export async function resolve(
+  connection: Connection,
+  domain: string,
+): Promise<ResolveResult> {
+  return resolveSIPStealth(connection, domain)
+}
+
+export async function publish(
+  connection: Connection,
+  domain: string,
+  wallet: WalletContextState,
+): Promise<{ signature: string }> {
+  if (!wallet.publicKey || !wallet.signMessage || !wallet.sendTransaction) {
+    throw new Error(
+      "Wallet not connected or does not support signMessage/sendTransaction",
+    )
+  }
+
+  const keys = await deriveStealthKeys(
+    { signMessage: wallet.signMessage },
+    domain,
+  )
+
+  const tx = await buildPublishTx(
+    connection,
+    domain,
+    { spending: keys.spending, viewing: keys.viewing },
+    wallet.publicKey,
+  )
+
+  const signature = await wallet.sendTransaction(tx, connection)
+  invalidateCache(domain)
+  return { signature }
+}
+
+export {
+  invalidateCache,
+  MetaAddress,
+  Malformed,
+  NetworkError,
+  NotFound,
+  OnChainError,
+  UserRejected,
+}
+export type { ResolveResult }

--- a/src/lib/sns-stealth-client.ts
+++ b/src/lib/sns-stealth-client.ts
@@ -18,7 +18,7 @@ import type { WalletContextState } from "@solana/wallet-adapter-react"
 
 export async function resolve(
   connection: Connection,
-  domain: string,
+  domain: string
 ): Promise<ResolveResult> {
   return resolveSIPStealth(connection, domain)
 }
@@ -26,24 +26,24 @@ export async function resolve(
 export async function publish(
   connection: Connection,
   domain: string,
-  wallet: WalletContextState,
+  wallet: WalletContextState
 ): Promise<{ signature: string }> {
   if (!wallet.publicKey || !wallet.signMessage || !wallet.sendTransaction) {
     throw new Error(
-      "Wallet not connected or does not support signMessage/sendTransaction",
+      "Wallet not connected or does not support signMessage/sendTransaction"
     )
   }
 
   const keys = await deriveStealthKeys(
     { signMessage: wallet.signMessage },
-    domain,
+    domain
   )
 
   const tx = await buildPublishTx(
     connection,
     domain,
     { spending: keys.spending, viewing: keys.viewing },
-    wallet.publicKey,
+    wallet.publicKey
   )
 
   const signature = await wallet.sendTransaction(tx, connection)

--- a/tests/app/wallet/sip-stealth/PublishCard.test.tsx
+++ b/tests/app/wallet/sip-stealth/PublishCard.test.tsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { PublicKey } from "@solana/web3.js"
+
+// ── mock class registry (populated inside vi.mock factory) ────────────────────
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockClasses: Record<string, new (...args: any[]) => unknown> = {}
+
+// ── mocks ───────────────────────────────────────────────────────────────────
+
+const mockReverseLookup = vi.fn()
+vi.mock("@bonfida/spl-name-service", () => ({
+  reverseLookup: (...args: unknown[]) => mockReverseLookup(...args),
+}))
+
+const mockResolve = vi.fn()
+const mockPublish = vi.fn()
+
+vi.mock("@/lib/sns-stealth-client", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  class MetaAddress { constructor(..._: any[]) {} }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  class NotFound { constructor(..._: any[]) {} }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  class Malformed { constructor(..._: any[]) {} }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  class UserRejected { constructor(..._: any[]) {} }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  class NetworkError { constructor(..._: any[]) {} }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  class OnChainError { constructor(..._: any[]) {} }
+
+  // Register for outer-scope use
+  Object.assign(MockClasses, { MetaAddress, NotFound, Malformed, UserRejected, NetworkError, OnChainError })
+
+  return {
+    resolve: (...args: unknown[]) => mockResolve(...args),
+    publish: (...args: unknown[]) => mockPublish(...args),
+    MetaAddress,
+    NotFound,
+    Malformed,
+    UserRejected,
+    NetworkError,
+    OnChainError,
+    invalidateCache: vi.fn(),
+  }
+})
+
+const mockGetExplorerUrl = vi.fn((sig: string) => `https://solscan.io/tx/${sig}`)
+vi.mock("@/stores/network", () => ({
+  useNetworkStore: {
+    getState: () => ({ getExplorerUrl: mockGetExplorerUrl }),
+  },
+}))
+
+const mockConnection = {}
+const mockWallet = {
+  publicKey: new PublicKey("CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB"),
+  connected: true,
+  signMessage: vi.fn(),
+  sendTransaction: vi.fn(),
+}
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => mockWallet,
+  useConnection: () => ({ connection: mockConnection }),
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const DOMAIN_PUBKEY = "CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB"
+const BARE_NAME = "rector"
+const FULL_DOMAIN = "rector.sol"
+
+async function renderCard(domainPubkey = DOMAIN_PUBKEY) {
+  const { PublishCard } = await import(
+    "@/app/(wallet)/wallet/sip-stealth/PublishCard"
+  )
+  return render(<PublishCard domainPubkey={domainPubkey} />)
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("PublishCard", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockReverseLookup.mockReset()
+    mockResolve.mockReset()
+    mockPublish.mockReset()
+    mockGetExplorerUrl.mockImplementation((sig: string) => `https://solscan.io/tx/${sig}`)
+  })
+
+  // ── loading state ──────────────────────────────────────────────────────────
+
+  it("shows loading skeleton on mount before resolution completes", async () => {
+    mockReverseLookup.mockReturnValue(new Promise(() => {}))
+
+    await renderCard()
+
+    expect(document.querySelector('[aria-busy="true"]')).toBeInTheDocument()
+    expect(document.querySelector('[aria-label="Loading domain"]')).toBeInTheDocument()
+  })
+
+  // ── has-record state ───────────────────────────────────────────────────────
+
+  it("shows 'Private payments enabled' when a MetaAddress record exists", async () => {
+    mockReverseLookup.mockResolvedValue(BARE_NAME)
+    mockResolve.mockResolvedValue(new MockClasses.MetaAddress())
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByText("Private payments enabled")).toBeInTheDocument()
+    })
+    expect(screen.getByText(FULL_DOMAIN)).toBeInTheDocument()
+    // Enable button must NOT be present
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  // ── no-record state ────────────────────────────────────────────────────────
+
+  it("shows Enable button when NotFound is returned", async () => {
+    mockReverseLookup.mockResolvedValue(BARE_NAME)
+    mockResolve.mockResolvedValue(new MockClasses.NotFound())
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument()
+    })
+    expect(screen.getByText(FULL_DOMAIN)).toBeInTheDocument()
+    expect(screen.queryByText("Private payments enabled")).not.toBeInTheDocument()
+  })
+
+  it("shows Enable button when Malformed is returned", async () => {
+    mockReverseLookup.mockResolvedValue(BARE_NAME)
+    mockResolve.mockResolvedValue(new MockClasses.Malformed())
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument()
+    })
+  })
+
+  // ── publish → success ──────────────────────────────────────────────────────
+
+  it("transitions to published state after successful publish", async () => {
+    const SIG = "5MrK1ExAbcDef123456789abcdef"
+    mockReverseLookup.mockResolvedValue(BARE_NAME)
+    mockResolve.mockResolvedValue(new MockClasses.NotFound())
+    mockPublish.mockResolvedValue({ signature: SIG })
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Enable/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Published")).toBeInTheDocument()
+    })
+
+    // Explorer link
+    const link = screen.getByRole("link")
+    expect(link).toHaveAttribute("href", `https://solscan.io/tx/${SIG}`)
+    expect(link).toHaveAttribute("target", "_blank")
+    expect(mockGetExplorerUrl).toHaveBeenCalledWith(SIG)
+  })
+
+  it("shows 'Publishing…' in button while in-flight", async () => {
+    mockReverseLookup.mockResolvedValue(BARE_NAME)
+    mockResolve.mockResolvedValue(new MockClasses.NotFound())
+    // Never resolves — keeps publishing state
+    mockPublish.mockReturnValue(new Promise(() => {}))
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Enable/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Publishing/i })).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole("button")).toBeDisabled()
+  })
+
+  // ── publish → error ────────────────────────────────────────────────────────
+
+  it("shows error message and re-enables button on generic publish failure", async () => {
+    mockReverseLookup.mockResolvedValue(BARE_NAME)
+    mockResolve.mockResolvedValue(new MockClasses.NotFound())
+    mockPublish.mockRejectedValue(new Error("RPC error"))
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Enable/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("RPC error")).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole("button", { name: /Enable/i })).not.toBeDisabled()
+  })
+
+  it("shows 'Transaction rejected' for UserRejected error", async () => {
+    mockReverseLookup.mockResolvedValue(BARE_NAME)
+    mockResolve.mockResolvedValue(new MockClasses.NotFound())
+    mockPublish.mockRejectedValue(new MockClasses.UserRejected())
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Enable/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Transaction rejected")).toBeInTheDocument()
+    })
+  })
+
+  // ── error loading card ─────────────────────────────────────────────────────
+
+  it("shows error card when reverseLookup throws", async () => {
+    mockReverseLookup.mockRejectedValue(new Error("Domain not found"))
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByText("Domain not found")).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  // ── publish passes correct args ────────────────────────────────────────────
+
+  it("calls publish with connection, full domain, and wallet", async () => {
+    mockReverseLookup.mockResolvedValue(BARE_NAME)
+    mockResolve.mockResolvedValue(new MockClasses.NotFound())
+    mockPublish.mockResolvedValue({ signature: "sig123" })
+
+    await renderCard()
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Enable/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Enable/i }))
+
+    await waitFor(() => {
+      expect(mockPublish).toHaveBeenCalledWith(mockConnection, FULL_DOMAIN, mockWallet)
+    })
+  })
+})

--- a/tests/app/wallet/sip-stealth/PublishCard.test.tsx
+++ b/tests/app/wallet/sip-stealth/PublishCard.test.tsx
@@ -48,9 +48,9 @@ vi.mock("@/lib/sns-stealth-client", () => {
 
 const mockGetExplorerUrl = vi.fn((sig: string) => `https://solscan.io/tx/${sig}`)
 vi.mock("@/stores/network", () => ({
-  useNetworkStore: {
-    getState: () => ({ getExplorerUrl: mockGetExplorerUrl }),
-  },
+  useNetworkStore: <T,>(
+    selector: (s: { getExplorerUrl: typeof mockGetExplorerUrl }) => T,
+  ): T => selector({ getExplorerUrl: mockGetExplorerUrl }),
 }))
 
 const mockConnection = {}

--- a/tests/app/wallet/sip-stealth/page.test.tsx
+++ b/tests/app/wallet/sip-stealth/page.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { PublicKey } from "@solana/web3.js"
+
+// ── mocks ───────────────────────────────────────────────────────────────────
+
+const mockGetAllDomains = vi.fn()
+vi.mock("@bonfida/spl-name-service", () => ({
+  getAllDomains: (...args: unknown[]) => mockGetAllDomains(...args),
+}))
+
+// PublishCard is a complex child — stub it so page tests stay focused
+vi.mock(
+  "@/app/(wallet)/wallet/sip-stealth/PublishCard",
+  () => ({
+    PublishCard: ({ domainPubkey }: { domainPubkey: string }) => (
+      <div data-testid={`publish-card-${domainPubkey}`}>card-{domainPubkey.slice(0, 4)}</div>
+    ),
+  }),
+)
+
+const mockConnection = {}
+let mockWallet = {
+  publicKey: null as PublicKey | null,
+  connected: false,
+}
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => mockWallet,
+  useConnection: () => ({ connection: mockConnection }),
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const PUBKEY_A = new PublicKey("CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB")
+const PUBKEY_B = new PublicKey("7x3Fh9wKLmPQrYvNJeS5tWXB2kZdGcA4np8Hu1VfRz6E")
+
+async function renderPage() {
+  const { default: SipStealthPage } = await import(
+    "@/app/(wallet)/wallet/sip-stealth/page"
+  )
+  return render(<SipStealthPage />)
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("SipStealthPage", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockGetAllDomains.mockReset()
+    mockWallet = { publicKey: null, connected: false }
+  })
+
+  it("shows wallet-not-connected state when wallet is disconnected", async () => {
+    await renderPage()
+    expect(screen.getByText("Connect your wallet")).toBeInTheDocument()
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument()
+    expect(mockGetAllDomains).not.toHaveBeenCalled()
+  })
+
+  it("shows page header regardless of wallet state", async () => {
+    await renderPage()
+    expect(screen.getByText("Enable Private Payments")).toBeInTheDocument()
+  })
+
+  it("shows loading state while domains are being fetched", async () => {
+    mockWallet = { publicKey: PUBKEY_A, connected: true }
+    // Don't resolve yet
+    mockGetAllDomains.mockReturnValue(new Promise(() => {}))
+
+    await renderPage()
+
+    // Loading state is set via queueMicrotask, so wait for it
+    await waitFor(() => {
+      const skeletons = document.querySelectorAll('[aria-hidden="true"]')
+      expect(skeletons.length).toBe(3)
+    })
+  })
+
+  it("shows empty state when user has no .sol domains", async () => {
+    mockWallet = { publicKey: PUBKEY_A, connected: true }
+    mockGetAllDomains.mockResolvedValue([])
+
+    await renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("No .sol domains found")).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Get a .sol domain/)).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Get a .sol domain/ })).toHaveAttribute(
+      "href",
+      "https://sns.id",
+    )
+  })
+
+  it("renders a PublishCard for each domain when domains are loaded", async () => {
+    mockWallet = { publicKey: PUBKEY_A, connected: true }
+    mockGetAllDomains.mockResolvedValue([PUBKEY_A, PUBKEY_B])
+
+    await renderPage()
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`publish-card-${PUBKEY_A.toBase58()}`),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByTestId(`publish-card-${PUBKEY_B.toBase58()}`),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("shows error state when getAllDomains rejects", async () => {
+    mockWallet = { publicKey: PUBKEY_A, connected: true }
+    mockGetAllDomains.mockRejectedValue(new Error("RPC timeout"))
+
+    await renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load domains")).toBeInTheDocument()
+      expect(screen.getByText("RPC timeout")).toBeInTheDocument()
+    })
+  })
+
+  it("does not call getAllDomains when wallet disconnects mid-render", async () => {
+    // Start disconnected — transition to connected is out of scope here,
+    // but we verify disconnected path stays inert.
+    mockWallet = { publicKey: null, connected: false }
+    await renderPage()
+    expect(mockGetAllDomains).not.toHaveBeenCalled()
+  })
+
+  it("passes correct connection and publicKey to getAllDomains", async () => {
+    mockWallet = { publicKey: PUBKEY_A, connected: true }
+    mockGetAllDomains.mockResolvedValue([])
+
+    await renderPage()
+
+    await waitFor(() => {
+      expect(mockGetAllDomains).toHaveBeenCalledWith(mockConnection, PUBKEY_A)
+    })
+  })
+})

--- a/tests/components/payments/recipient-input.test.tsx
+++ b/tests/components/payments/recipient-input.test.tsx
@@ -1,46 +1,435 @@
-import { describe, it, expect, vi } from "vitest"
-import { render, screen, fireEvent } from "@testing-library/react"
-import {
-  RecipientInput,
-  validateRecipient,
-} from "@/components/payments/recipient-input"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
+import { PublicKey } from "@solana/web3.js"
 
-describe("validateRecipient", () => {
-  it("validates correct sip address format", () => {
-    const validAddress =
-      "sip:solana:CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB:7x3Fh9wKLmPQrYvNJeS5tWXB2kZdGcA4np8Hu1VfRz6E"
-    expect(validateRecipient(validAddress)).toBe(true)
+// ── Mock class registry (populated inside vi.mock factory) ─────────────────
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockClasses: Record<string, new (...args: any[]) => unknown> = {}
+
+// ── Mock @/lib/sns-stealth-client ──────────────────────────────────────────
+
+const mockSnsResolve = vi.fn()
+
+vi.mock("@/lib/sns-stealth-client", () => {
+  class MetaAddress {
+    spending: Uint8Array
+    viewing: Uint8Array
+    chain: string
+    domain: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(args: any) {
+      this.spending = args.spending
+      this.viewing = args.viewing
+      this.chain = args.chain ?? "solana"
+      this.domain = args.domain ?? ""
+    }
+  }
+  class NotFound {
+    subject: string
+    constructor(subject: string) { this.subject = subject }
+  }
+  class Malformed {
+    reason: string
+    constructor(reason: string) { this.reason = reason }
+  }
+  class NetworkError extends Error {}
+  class OnChainError extends Error {}
+  class UserRejected extends Error {}
+
+  Object.assign(MockClasses, { MetaAddress, NotFound, Malformed, NetworkError, OnChainError, UserRejected })
+
+  return {
+    resolve: (...args: unknown[]) => mockSnsResolve(...args),
+    MetaAddress,
+    NotFound,
+    Malformed,
+    NetworkError,
+    OnChainError,
+    UserRejected,
+    invalidateCache: vi.fn(),
+  }
+})
+
+// ── Mock @bonfida/spl-name-service ─────────────────────────────────────────
+
+const mockBonfidaResolve = vi.fn()
+
+vi.mock("@bonfida/spl-name-service", () => ({
+  resolve: (...args: unknown[]) => mockBonfidaResolve(...args),
+}))
+
+// ── Mock @solana/wallet-adapter-react ──────────────────────────────────────
+
+const mockConnection = {}
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useConnection: () => ({ connection: mockConnection }),
+  useWallet: () => ({ publicKey: null, connected: false }),
+}))
+
+// ── Mock logger ────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const VALID_SIP =
+  "sip:solana:CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB:7x3Fh9wKLmPQrYvNJeS5tWXB2kZdGcA4np8Hu1VfRz6E"
+
+// 32-byte Uint8Array stubs representing spending/viewing keys
+const SPENDING_BYTES = new Uint8Array(32).fill(1)
+const VIEWING_BYTES = new Uint8Array(32).fill(2)
+
+// bs58 encode of 32 bytes filled with 0x01 / 0x02
+// we don't hard-code the exact base58; we verify the resulting URI shape instead
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function renderInput(value = "", onChange = vi.fn(), onResolutionChange = vi.fn()) {
+  const { RecipientInput } = await import("@/components/payments/recipient-input")
+  return render(
+    <RecipientInput
+      value={value}
+      onChange={onChange}
+      onResolutionChange={onResolutionChange}
+    />,
+  )
+}
+
+// ── backward compat: validateRecipient ────────────────────────────────────
+
+describe("validateRecipient (backward compat)", () => {
+  it("validates correct sip address format", async () => {
+    const { validateRecipient } = await import("@/components/payments/recipient-input")
+    expect(validateRecipient(VALID_SIP)).toBe(true)
   })
 
-  it("rejects invalid formats", () => {
+  it("rejects invalid formats", async () => {
+    const { validateRecipient } = await import("@/components/payments/recipient-input")
     expect(validateRecipient("")).toBe(false)
     expect(validateRecipient("invalid")).toBe(false)
     expect(validateRecipient("sip:ethereum:abc:def")).toBe(false)
     expect(validateRecipient("0x1234")).toBe(false)
+    expect(validateRecipient("alice.sol")).toBe(false) // SNS requires async resolution
   })
 })
 
-describe("RecipientInput", () => {
-  it("renders with placeholder", () => {
-    render(<RecipientInput value="" onChange={() => {}} />)
-    expect(screen.getByPlaceholderText(/sip:solana/)).toBeInTheDocument()
+// ── RecipientInput: rendering ─────────────────────────────────────────────
+
+describe("RecipientInput - rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
-  it("calls onChange when typing", () => {
+  it("renders with updated placeholder accepting .sol", async () => {
+    await renderInput()
+    const input = screen.getByRole("textbox")
+    expect(input.getAttribute("placeholder")).toMatch(/alice\.sol/)
+  })
+
+  it("shows help text when empty", async () => {
+    await renderInput()
+    expect(screen.getByText(/\.sol domain or SIP stealth/i)).toBeInTheDocument()
+  })
+
+  it("calls onChange when typing", async () => {
     const onChange = vi.fn()
-    render(<RecipientInput value="" onChange={onChange} />)
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "test" } })
-    expect(onChange).toHaveBeenCalledWith("test")
+    await renderInput("", onChange)
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "alice.sol" } })
+    expect(onChange).toHaveBeenCalledWith("alice.sol")
   })
 
-  it("shows error for invalid address after blur", () => {
-    render(<RecipientInput value="invalid" onChange={() => {}} />)
-    fireEvent.blur(screen.getByRole("textbox"))
-    expect(screen.getByText(/Invalid stealth address/)).toBeInTheDocument()
-  })
-
-  it("disables input when disabled prop is true", () => {
+  it("disables input when disabled prop is true", async () => {
+    const { RecipientInput } = await import("@/components/payments/recipient-input")
     render(<RecipientInput value="" onChange={() => {}} disabled />)
     expect(screen.getByRole("textbox")).toBeDisabled()
+  })
+})
+
+// ── RecipientInput: sip: URI (backward compat) ─────────────────────────────
+
+describe("RecipientInput - sip: URI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows green confirmation for valid sip: URI", async () => {
+    const onResolutionChange = vi.fn()
+    await renderInput(VALID_SIP, vi.fn(), onResolutionChange)
+
+    expect(screen.getByText(/SIP stealth address ready/i)).toBeInTheDocument()
+    expect(onResolutionChange).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "sip-uri", uri: VALID_SIP }),
+    )
+  })
+
+  it("shows error for invalid input after blur", async () => {
+    await renderInput("not-valid-garbage")
+    fireEvent.blur(screen.getByRole("textbox"))
+    expect(screen.getByText(/Invalid format/i)).toBeInTheDocument()
+  })
+})
+
+// ── RecipientInput: SNS resolving state ────────────────────────────────────
+
+describe("RecipientInput - SNS resolving", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Keep mockSnsResolve pending indefinitely so we can inspect the resolving state
+    mockSnsResolve.mockReturnValue(new Promise(() => {}))
+  })
+
+  it("shows resolving spinner while SNS lookup is in flight", async () => {
+    const onResolutionChange = vi.fn()
+    await renderInput("alice.sol", vi.fn(), onResolutionChange)
+
+    // Resolving state is set synchronously (before debounce fires)
+    expect(onResolutionChange).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "sns-resolving", domain: "alice.sol" }),
+    )
+    expect(screen.getByText(/Resolving alice\.sol/i)).toBeInTheDocument()
+  })
+})
+
+// ── RecipientInput: SNS resolved ───────────────────────────────────────────
+
+describe("RecipientInput - SNS resolved (SIP-STEALTH record found)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows green confirmation and calls onResolutionChange with sns-resolved", async () => {
+    const { MetaAddress } = MockClasses
+    mockSnsResolve.mockResolvedValue(
+      new (MetaAddress as new (a: object) => { spending: Uint8Array; viewing: Uint8Array })({
+        spending: SPENDING_BYTES,
+        viewing: VIEWING_BYTES,
+        chain: "solana",
+        domain: "alice.sol",
+      }),
+    )
+
+    const onResolutionChange = vi.fn()
+    await renderInput("alice.sol", vi.fn(), onResolutionChange)
+
+    await waitFor(() => {
+      expect(onResolutionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "sns-resolved", domain: "alice.sol" }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/alice\.sol.*private payment available/i)).toBeInTheDocument()
+    })
+  })
+
+  it("builds a valid sip: URI from MetaAddress bytes", async () => {
+    const { MetaAddress } = MockClasses
+    mockSnsResolve.mockResolvedValue(
+      new (MetaAddress as new (a: object) => unknown)({
+        spending: SPENDING_BYTES,
+        viewing: VIEWING_BYTES,
+        chain: "solana",
+        domain: "alice.sol",
+      }),
+    )
+
+    const onResolutionChange = vi.fn()
+    await renderInput("alice.sol", vi.fn(), onResolutionChange)
+
+    await waitFor(() => {
+      const calls = onResolutionChange.mock.calls as Array<[{ kind: string; uri?: string }]>
+      const resolved = calls.find(([r]) => r.kind === "sns-resolved")
+      expect(resolved).toBeDefined()
+      const r = resolved![0]
+      expect(r.uri).toMatch(/^sip:solana:[1-9A-HJ-NP-Za-km-z]{32,44}:[1-9A-HJ-NP-Za-km-z]{32,44}$/)
+    })
+  })
+})
+
+// ── RecipientInput: SNS not-found-record ───────────────────────────────────
+
+describe("RecipientInput - SNS not-found-record", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const { NotFound } = MockClasses
+    mockSnsResolve.mockResolvedValue(
+      new (NotFound as new (s: string) => unknown)("record"),
+    )
+  })
+
+  it("shows yellow warning box with domain name", async () => {
+    await renderInput("alice.sol")
+
+    await waitFor(() => {
+      expect(screen.getByText(/Private payment not available/i)).toBeInTheDocument()
+      expect(screen.getByText(/alice\.sol hasn't enabled SIP-STEALTH/i)).toBeInTheDocument()
+    })
+  })
+
+  it("shows Send Public and Cancel buttons", async () => {
+    await renderInput("alice.sol")
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Send Public/i })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /Cancel/i })).toBeInTheDocument()
+    })
+  })
+
+  it("Cancel button calls onChange with empty string", async () => {
+    const onChange = vi.fn()
+    await renderInput("alice.sol", onChange)
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Cancel/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }))
+    expect(onChange).toHaveBeenCalledWith("")
+  })
+
+  it("Send Public button resolves via Bonfida and shows public address preview", async () => {
+    const PUBLIC_KEY = new PublicKey("CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB")
+    mockBonfidaResolve.mockResolvedValue(PUBLIC_KEY)
+
+    await renderInput("alice.sol")
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Send Public/i })).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Send Public/i }))
+    })
+
+    await waitFor(() => {
+      expect(mockBonfidaResolve).toHaveBeenCalledWith(
+        mockConnection,
+        "alice.sol",
+      )
+      expect(
+        screen.getByText(/CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB/),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("Send Public shows error when Bonfida resolve throws", async () => {
+    mockBonfidaResolve.mockRejectedValue(new Error("Domain not found"))
+
+    await renderInput("alice.sol")
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Send Public/i })).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Send Public/i }))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Could not look up public address/i),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("calls onResolutionChange with sns-not-found-record", async () => {
+    const onResolutionChange = vi.fn()
+    await renderInput("alice.sol", vi.fn(), onResolutionChange)
+
+    await waitFor(() => {
+      expect(onResolutionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "sns-not-found-record", domain: "alice.sol" }),
+      )
+    })
+  })
+})
+
+// ── RecipientInput: SNS not-found-domain ──────────────────────────────────
+
+describe("RecipientInput - SNS not-found-domain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const { NotFound } = MockClasses
+    mockSnsResolve.mockResolvedValue(
+      new (NotFound as new (s: string) => unknown)("domain"),
+    )
+  })
+
+  it("shows red error message", async () => {
+    await renderInput("nobody.sol")
+
+    await waitFor(() => {
+      expect(screen.getByText(/nobody\.sol not found/i)).toBeInTheDocument()
+    })
+  })
+
+  it("calls onResolutionChange with sns-not-found-domain", async () => {
+    const onResolutionChange = vi.fn()
+    await renderInput("nobody.sol", vi.fn(), onResolutionChange)
+
+    await waitFor(() => {
+      expect(onResolutionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "sns-not-found-domain", domain: "nobody.sol" }),
+      )
+    })
+  })
+})
+
+// ── RecipientInput: SNS malformed ──────────────────────────────────────────
+
+describe("RecipientInput - SNS malformed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const { Malformed } = MockClasses
+    mockSnsResolve.mockResolvedValue(
+      new (Malformed as new (s: string) => unknown)("json-parse"),
+    )
+  })
+
+  it("shows red error with reason", async () => {
+    await renderInput("broken.sol")
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/broken\.sol's privacy record is invalid \(json-parse\)/i),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("calls onResolutionChange with sns-malformed", async () => {
+    const onResolutionChange = vi.fn()
+    await renderInput("broken.sol", vi.fn(), onResolutionChange)
+
+    await waitFor(() => {
+      expect(onResolutionChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "sns-malformed",
+          domain: "broken.sol",
+          reason: "json-parse",
+        }),
+      )
+    })
+  })
+})
+
+// ── RecipientInput: network error fallback ────────────────────────────────
+
+describe("RecipientInput - network error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSnsResolve.mockRejectedValue(new Error("network timeout"))
+  })
+
+  it("falls back to sns-not-found-domain on network error", async () => {
+    const onResolutionChange = vi.fn()
+    await renderInput("alice.sol", vi.fn(), onResolutionChange)
+
+    await waitFor(() => {
+      expect(onResolutionChange).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "sns-not-found-domain", domain: "alice.sol" }),
+      )
+    })
   })
 })

--- a/tests/components/payments/recipient-resolution.test.ts
+++ b/tests/components/payments/recipient-resolution.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest"
+import {
+  classifyInput,
+  isReadyToSend,
+  targetUri,
+  SIP_ADDRESS_REGEX,
+  SNS_DOMAIN_REGEX,
+  type RecipientResolution,
+} from "@/components/payments/recipient-resolution"
+
+// ── fixture helpers ────────────────────────────────────────────────────────────
+
+const VALID_SIP =
+  "sip:solana:CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB:7x3Fh9wKLmPQrYvNJeS5tWXB2kZdGcA4np8Hu1VfRz6E"
+
+// ── SIP_ADDRESS_REGEX ─────────────────────────────────────────────────────────
+
+describe("SIP_ADDRESS_REGEX", () => {
+  it("matches a valid sip:solana URI", () => {
+    expect(SIP_ADDRESS_REGEX.test(VALID_SIP)).toBe(true)
+  })
+
+  it("rejects sip:ethereum URIs", () => {
+    expect(
+      SIP_ADDRESS_REGEX.test(
+        "sip:ethereum:CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB:7x3Fh9wKLmPQrYvNJeS5tWXB2kZdGcA4np8Hu1VfRz6E",
+      ),
+    ).toBe(false)
+  })
+
+  it("rejects URIs with missing viewing key", () => {
+    expect(
+      SIP_ADDRESS_REGEX.test(
+        "sip:solana:CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB",
+      ),
+    ).toBe(false)
+  })
+
+  it("rejects empty string", () => {
+    expect(SIP_ADDRESS_REGEX.test("")).toBe(false)
+  })
+
+  it("rejects plain Solana address", () => {
+    expect(
+      SIP_ADDRESS_REGEX.test("CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB"),
+    ).toBe(false)
+  })
+})
+
+// ── SNS_DOMAIN_REGEX ──────────────────────────────────────────────────────────
+
+describe("SNS_DOMAIN_REGEX", () => {
+  it("matches simple .sol domain", () => {
+    expect(SNS_DOMAIN_REGEX.test("alice.sol")).toBe(true)
+  })
+
+  it("matches subdomain .sol", () => {
+    expect(SNS_DOMAIN_REGEX.test("pay.alice.sol")).toBe(true)
+  })
+
+  it("matches uppercase (case-insensitive flag)", () => {
+    expect(SNS_DOMAIN_REGEX.test("ALICE.SOL")).toBe(true)
+  })
+
+  it("matches hyphenated domain", () => {
+    expect(SNS_DOMAIN_REGEX.test("my-wallet.sol")).toBe(true)
+  })
+
+  it("rejects domain without .sol suffix", () => {
+    expect(SNS_DOMAIN_REGEX.test("alice.eth")).toBe(false)
+  })
+
+  it("rejects bare .sol", () => {
+    expect(SNS_DOMAIN_REGEX.test(".sol")).toBe(false)
+  })
+
+  it("rejects domain with trailing dot (before trim)", () => {
+    // classifyInput strips trailing dot; regex itself rejects it
+    expect(SNS_DOMAIN_REGEX.test("alice.sol.")).toBe(false)
+  })
+})
+
+// ── classifyInput ─────────────────────────────────────────────────────────────
+
+describe("classifyInput", () => {
+  it("returns empty for blank string", () => {
+    expect(classifyInput("")).toStrictEqual({ kind: "empty" })
+  })
+
+  it("returns empty for whitespace-only string", () => {
+    expect(classifyInput("   ")).toStrictEqual({ kind: "empty" })
+  })
+
+  it("returns sip-uri for a valid sip:solana URI", () => {
+    expect(classifyInput(VALID_SIP)).toStrictEqual({
+      kind: "sip-uri",
+      uri: VALID_SIP,
+    })
+  })
+
+  it("trims whitespace before classifying sip URI", () => {
+    expect(classifyInput(`  ${VALID_SIP}  `)).toStrictEqual({
+      kind: "sip-uri",
+      uri: VALID_SIP,
+    })
+  })
+
+  it("returns sns-resolving for alice.sol", () => {
+    expect(classifyInput("alice.sol")).toStrictEqual({
+      kind: "sns-resolving",
+      domain: "alice.sol",
+    })
+  })
+
+  it("lowercases the domain in sns-resolving", () => {
+    expect(classifyInput("ALICE.SOL")).toStrictEqual({
+      kind: "sns-resolving",
+      domain: "alice.sol",
+    })
+  })
+
+  it("strips trailing dot from domain", () => {
+    expect(classifyInput("alice.sol.")).toStrictEqual({
+      kind: "sns-resolving",
+      domain: "alice.sol",
+    })
+  })
+
+  it("returns invalid for a bare Solana address", () => {
+    const r = classifyInput("CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB")
+    expect(r.kind).toBe("invalid")
+  })
+
+  it("returns invalid for random text", () => {
+    const r = classifyInput("hello world")
+    expect(r.kind).toBe("invalid")
+  })
+
+  it("returns invalid for sip:ethereum URI", () => {
+    const r = classifyInput(
+      "sip:ethereum:CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB:7x3Fh9wKLmPQrYvNJeS5tWXB2kZdGcA4np8Hu1VfRz6E",
+    )
+    expect(r.kind).toBe("invalid")
+  })
+})
+
+// ── isReadyToSend ─────────────────────────────────────────────────────────────
+
+describe("isReadyToSend", () => {
+  const readyCases: RecipientResolution[] = [
+    { kind: "sip-uri", uri: VALID_SIP },
+    { kind: "sns-resolved", domain: "alice.sol", uri: VALID_SIP },
+  ]
+
+  const notReadyCases: RecipientResolution[] = [
+    { kind: "empty" },
+    { kind: "sns-resolving", domain: "alice.sol" },
+    { kind: "sns-not-found-record", domain: "alice.sol" },
+    { kind: "sns-not-found-domain", domain: "alice.sol" },
+    { kind: "sns-malformed", domain: "alice.sol", reason: "json-parse" },
+    { kind: "invalid", input: "garbage" },
+  ]
+
+  for (const r of readyCases) {
+    it(`returns true for kind="${r.kind}"`, () => {
+      expect(isReadyToSend(r)).toBe(true)
+    })
+  }
+
+  for (const r of notReadyCases) {
+    it(`returns false for kind="${r.kind}"`, () => {
+      expect(isReadyToSend(r)).toBe(false)
+    })
+  }
+})
+
+// ── targetUri ─────────────────────────────────────────────────────────────────
+
+describe("targetUri", () => {
+  it("returns uri from sip-uri resolution", () => {
+    expect(
+      targetUri({ kind: "sip-uri", uri: VALID_SIP }),
+    ).toBe(VALID_SIP)
+  })
+
+  it("returns uri from sns-resolved resolution", () => {
+    expect(
+      targetUri({ kind: "sns-resolved", domain: "alice.sol", uri: VALID_SIP }),
+    ).toBe(VALID_SIP)
+  })
+
+  it("returns null for non-ready states", () => {
+    expect(targetUri({ kind: "empty" })).toBeNull()
+    expect(targetUri({ kind: "sns-resolving", domain: "alice.sol" })).toBeNull()
+    expect(targetUri({ kind: "sns-not-found-record", domain: "alice.sol" })).toBeNull()
+    expect(targetUri({ kind: "invalid", input: "garbage" })).toBeNull()
+  })
+})

--- a/tests/components/payments/send-shielded-form.test.tsx
+++ b/tests/components/payments/send-shielded-form.test.tsx
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { PublicKey } from "@solana/web3.js"
+
+// ── Mock class registry ────────────────────────────────────────────────────
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockClasses: Record<string, new (...args: any[]) => unknown> = {}
+
+// ── Mock @/lib/sns-stealth-client ──────────────────────────────────────────
+
+const mockSnsResolve = vi.fn()
+
+vi.mock("@/lib/sns-stealth-client", () => {
+  class MetaAddress {
+    spending: Uint8Array
+    viewing: Uint8Array
+    chain: string
+    domain: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(args: any) {
+      this.spending = args.spending
+      this.viewing = args.viewing
+      this.chain = args.chain ?? "solana"
+      this.domain = args.domain ?? ""
+    }
+  }
+  class NotFound {
+    subject: string
+    constructor(subject: string) { this.subject = subject }
+  }
+  class Malformed {
+    reason: string
+    constructor(reason: string) { this.reason = reason }
+  }
+  class NetworkError extends Error {}
+  class OnChainError extends Error {}
+  class UserRejected extends Error {}
+
+  Object.assign(MockClasses, { MetaAddress, NotFound, Malformed, NetworkError, OnChainError, UserRejected })
+
+  return {
+    resolve: (...args: unknown[]) => mockSnsResolve(...args),
+    MetaAddress,
+    NotFound,
+    Malformed,
+    NetworkError,
+    OnChainError,
+    UserRejected,
+    invalidateCache: vi.fn(),
+  }
+})
+
+// ── Mock @bonfida/spl-name-service ─────────────────────────────────────────
+
+vi.mock("@bonfida/spl-name-service", () => ({
+  resolve: vi.fn(),
+}))
+
+// ── Mock @solana/wallet-adapter-react ──────────────────────────────────────
+
+const mockPublicKey = new PublicKey("CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB")
+const mockConnection = {
+  getBalance: vi.fn().mockResolvedValue(5_000_000_000), // 5 SOL
+  rpcEndpoint: "https://api.mainnet-beta.solana.com",
+}
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({
+    publicKey: mockPublicKey,
+    connected: true,
+  }),
+  useConnection: () => ({ connection: mockConnection }),
+}))
+
+// ── Mock hooks ─────────────────────────────────────────────────────────────
+
+const mockSend = vi.fn()
+const mockReset = vi.fn()
+
+vi.mock("@/hooks/use-send-payment", () => ({
+  useSendPayment: () => ({
+    status: "idle",
+    txHash: null,
+    error: null,
+    currentStep: null,
+    send: mockSend,
+    reset: mockReset,
+  }),
+}))
+
+vi.mock("@/hooks/use-viewing-key-storage", () => ({
+  useViewingKeyStorage: () => ({ saveKey: vi.fn() }),
+}))
+
+// ── Mock stores ────────────────────────────────────────────────────────────
+
+vi.mock("@/stores/demo-mode", () => ({
+  useDemoModeStore: () => ({ isDemoMode: false, enableDemo: vi.fn() }),
+}))
+
+// ── Mock components (keep tests focused on form logic) ────────────────────
+
+vi.mock("@/components/ui/demo-banner", () => ({
+  DemoBanner: () => <div data-testid="demo-banner" />,
+}))
+
+vi.mock("@/components/payments/transaction-status", () => ({
+  TransactionStatus: ({ status }: { status: string }) => (
+    <div data-testid="tx-status">{status}</div>
+  ),
+}))
+
+vi.mock("@/components/payments/viewing-key", () => ({
+  ViewingKeyPanel: ({ onViewingKeyChange }: { onViewingKeyChange: (k: null) => void }) => (
+    <button type="button" onClick={() => onViewingKeyChange(null)}>
+      ViewingKeyPanel
+    </button>
+  ),
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const VALID_SIP =
+  "sip:solana:CVDFLCAjXhVWiPXH9nTCTpCgVzmDVoiPzNJYuccr1dqB:7x3Fh9wKLmPQrYvNJeS5tWXB2kZdGcA4np8Hu1VfRz6E"
+
+const SPENDING_BYTES = new Uint8Array(32).fill(1)
+const VIEWING_BYTES = new Uint8Array(32).fill(2)
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function renderForm() {
+  const { SendShieldedForm } = await import(
+    "@/components/payments/send-shielded-form"
+  )
+  return render(<SendShieldedForm />)
+}
+
+function getSubmitButton() {
+  return screen.getByRole("button", { name: /Send Shielded Payment/i })
+}
+
+function getRecipientInput() {
+  return screen.getByLabelText("Recipient") as HTMLInputElement
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("SendShieldedForm - submit gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: sns resolve stays pending (no interference)
+    mockSnsResolve.mockReturnValue(new Promise(() => {}))
+  })
+
+  it("submit button is disabled when recipient is empty", async () => {
+    await renderForm()
+    expect(getSubmitButton()).toBeDisabled()
+  })
+
+  it("submit button is disabled for invalid input", async () => {
+    await renderForm()
+    fireEvent.change(getRecipientInput(), { target: { value: "garbage" } })
+    // 'garbage' → invalid → not ready
+    expect(getSubmitButton()).toBeDisabled()
+  })
+
+  it("submit button is disabled while SNS is resolving", async () => {
+    await renderForm()
+    fireEvent.change(getRecipientInput(), { target: { value: "alice.sol" } })
+    // resolving state → not ready → disabled
+    expect(getSubmitButton()).toBeDisabled()
+  })
+
+  it("submit button enables after sip: URI entered + amount provided", async () => {
+    await renderForm()
+
+    fireEvent.change(getRecipientInput(), { target: { value: VALID_SIP } })
+    // Enter amount
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "0.01" },
+    })
+
+    await waitFor(() => {
+      expect(getSubmitButton()).not.toBeDisabled()
+    })
+  })
+
+  it("submit button is disabled when SNS resolves to not-found-record", async () => {
+    const { NotFound } = MockClasses
+    mockSnsResolve.mockResolvedValue(
+      new (NotFound as new (s: string) => unknown)("record"),
+    )
+
+    await renderForm()
+
+    fireEvent.change(getRecipientInput(), { target: { value: "alice.sol" } })
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "0.01" },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Private payment not available/i)).toBeInTheDocument()
+    })
+
+    expect(getSubmitButton()).toBeDisabled()
+  })
+})
+
+describe("SendShieldedForm - sip: URI submit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSnsResolve.mockReturnValue(new Promise(() => {}))
+    mockSend.mockResolvedValue({ txHash: "abc123" })
+  })
+
+  it("calls send() with the sip: URI as recipient", async () => {
+    await renderForm()
+
+    fireEvent.change(getRecipientInput(), { target: { value: VALID_SIP } })
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "0.1" },
+    })
+
+    await waitFor(() => expect(getSubmitButton()).not.toBeDisabled())
+
+    fireEvent.click(getSubmitButton())
+
+    await waitFor(() => {
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({ recipient: VALID_SIP }),
+      )
+    })
+  })
+})
+
+describe("SendShieldedForm - SNS resolved submit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const { MetaAddress } = MockClasses
+    mockSnsResolve.mockResolvedValue(
+      new (MetaAddress as new (a: object) => unknown)({
+        spending: SPENDING_BYTES,
+        viewing: VIEWING_BYTES,
+        chain: "solana",
+        domain: "alice.sol",
+      }),
+    )
+    mockSend.mockResolvedValue({ txHash: "snstxhash" })
+  })
+
+  it("calls send() with the resolved sip: URI (not the raw .sol input)", async () => {
+    await renderForm()
+
+    fireEvent.change(getRecipientInput(), { target: { value: "alice.sol" } })
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "0.05" },
+    })
+
+    // Wait for SNS resolution to complete
+    await waitFor(() => {
+      expect(screen.getByText(/alice\.sol.*private payment available/i)).toBeInTheDocument()
+    })
+
+    await waitFor(() => expect(getSubmitButton()).not.toBeDisabled())
+
+    fireEvent.click(getSubmitButton())
+
+    await waitFor(() => {
+      expect(mockSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // Must be a sip: URI, NOT "alice.sol"
+          recipient: expect.stringMatching(
+            /^sip:solana:[1-9A-HJ-NP-Za-km-z]{32,44}:[1-9A-HJ-NP-Za-km-z]{32,44}$/,
+          ),
+        }),
+      )
+    })
+  })
+})
+
+describe("SendShieldedForm - reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSnsResolve.mockReturnValue(new Promise(() => {}))
+  })
+
+  it("clears recipient and resets resolution on reset", async () => {
+    await renderForm()
+
+    fireEvent.change(getRecipientInput(), { target: { value: VALID_SIP } })
+    fireEvent.change(screen.getByLabelText("Amount"), {
+      target: { value: "0.01" },
+    })
+
+    await waitFor(() => expect(getSubmitButton()).not.toBeDisabled())
+
+    // Reset via the hook — we verify state was cleared by checking input is empty
+    // (we can't call handleReset directly, but we can check that setRecipient("") was fired)
+    // The reset is internal; we check the input is cleared by verifying
+    // re-render with empty recipient disables submit
+    fireEvent.change(getRecipientInput(), { target: { value: "" } })
+    expect(getSubmitButton()).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## Summary

Phase B of the sip.sol foundation — wires the freshly-published [`@sip-protocol/sns-stealth@0.1.0`](https://www.npmjs.com/package/@sip-protocol/sns-stealth) into sip-app so users can:

1. **Publish a SIP-STEALTH record** to their `.sol` domain (`/wallet/sip-stealth`)
2. **Send privately to a `<domain>.sol` recipient** — typing `alice.sol` in the recipient field resolves via SNS, builds the sip: URI on the fly, and submits through the existing shielded-payment flow

Companion to Phase A (PR sip-protocol/sip-protocol#1082, merged 2026-05-11).

### What's in here

| Commit | Task | What |
|--------|------|------|
| `7b60e3b` | 11 | Add `@sip-protocol/sns-stealth@^0.1.0` + `@bonfida/spl-name-service@^3.0.21`; create `src/lib/sns-stealth-client.ts` (cluster-aware wrapper using `useConnection`) |
| `43c52e7` | 12 | `/wallet/sip-stealth` publish UI — page + per-domain `PublishCard` (lists via `getAllDomains`, detects existing record via `resolve()`, click → `publish()` with cluster-aware Solscan link) |
| `6aa7f55` | 12 | Quality fixes — `useNetworkStore` hook selector (reactive explorer URL), domain-scoped `aria-label` on Enable button, TS exhaustiveness guard |
| `6bbc9e0` | 13 | Recipient resolution state machine (`recipient-resolution.ts`) + smart `RecipientInput` (Option A: input owns the state, emits via `onResolutionChange`); 350ms debounce + generation-counter stale guard; bs58 URI build from `MetaAddress` |
| `893d9fc` | 13 | Quality fixes — `unmountedRef` guard against `setState` on unmounted (during in-flight resolve), `RSnsMalformed` rename, `aria-live` polite wrapper on feedback area, explanatory comment on the intentional `eslint-disable` |
| `71a47dc` | 14 | Playwright E2E (`e2e/mainnet/sip-sol.spec.ts`, 4 tests) — real Bonfida mainnet lookups |

## Test plan

- [x] **Unit:** `pnpm test:run` → 1261/1261 pass (1186 baseline + 75 new across 6 files: `recipient-resolution.test.ts`, `recipient-input.test.tsx`, `send-shielded-form.test.tsx`, `app/wallet/sip-stealth/page.test.tsx`, `app/wallet/sip-stealth/PublishCard.test.tsx`)
- [x] **Typecheck:** `pnpm typecheck` → clean
- [x] **Lint:** `pnpm lint` → 0 errors (4 pre-existing warnings in `empty-module.ts` / `yellowstone-grpc-stub.js`, unrelated)
- [x] **E2E:** `pnpm exec playwright test --project=mainnet e2e/mainnet/sip-sol.spec.ts` against `pnpm start` → 4/4 pass in ~57s
- [ ] **Manual dev-server verify** — see Known Issue #1 below; verified against `pnpm build && pnpm start` instead

## Architecture decisions

- **`RecipientInput` is "smart" (Option A)** — owns resolution state, debounce, stale-request cancellation, and all SNS-specific UX. `SendShieldedForm` consumes a tagged-union `RecipientResolution` via `onResolutionChange` and gates submit via `isReadyToSend(resolution)`. Keeps the form lean and lets the input be tested in isolation.
- **`useConnection()` everywhere** — the wrapper accepts a `Connection` from callers; no `new Connection(env)` or `process.env.NEXT_PUBLIC_SOLANA_RPC` reads. Respects `useNetworkStore` cluster (mainnet / devnet / custom RPC).
- **Explorer links via `useNetworkStore((s) => s.getExplorerUrl)`** (hook selector form) — reactive to cluster changes after publish, not snapshot.
- **Error classes re-exported from `@/lib/sns-stealth-client`** — single integration point for `MetaAddress` / `NotFound` / `Malformed` / `NetworkError` / `OnChainError` / `UserRejected`.
- **bs58 URI construction at the resolution boundary** — `MetaAddress.spending/viewing` (Uint8Array 32B) → `sip:solana:${bs58.encode}:${bs58.encode}`. The form's `useSendPayment.send()` contract is unchanged.

## Known Issues / Follow-ups

1. **Turbopack dev mode breaks pages that import `@bonfida/spl-name-service`** — the package transitively does `const { TextDecoder } = require('util')`, and Turbopack's util polyfill omits `TextDecoder` (same gap webpack handles via the existing `util$ → utilBrowser` alias in `next.config.ts`). Affects both `/payments/send` and `/wallet/sip-stealth` in `pnpm dev`. Production build (`pnpm build && pnpm start`, webpack) works correctly. **Fix:** Add Turbopack `resolveAlias` for `util` pointing at a Turbopack-compatible util shim. Tracked as separate work — out of scope here.
2. **"Send Public" handler is preview-only** — calls Bonfida `resolve()` to fetch the underlying Solana address and displays it with an explanatory note. Actually wiring a public send through the form requires the form to accept raw Solana addresses for transparent privacy. Deferred — TODO comment in `recipient-input.tsx`.
3. **Stale-request scenario lacks a dedicated test** — the generation-counter guard in `recipient-input.tsx` exists and is correct; rapid-input + concurrent resolve isn't exercised in the test suite. Implementation-level correctness already verified by the unmount + cancellation tests.
4. **Minor:** `publicAddressPreview` uses `"error"` as a string sentinel — works but could be a discriminated union. Not worth a separate commit.

## Files

```
 src/lib/sns-stealth-client.ts                          | 60 ++++++++++  (new)
 src/app/(wallet)/wallet/sip-stealth/page.tsx           | 157 +++++++++  (new)
 src/app/(wallet)/wallet/sip-stealth/PublishCard.tsx    | 214 ++++++++++  (new)
 src/components/payments/recipient-resolution.ts        |  97 +++++++++  (new)
 src/components/payments/recipient-input.tsx            | 555 (+267) →  (modified)
 src/components/payments/send-shielded-form.tsx         | 274  (+22) →  (modified)
 e2e/mainnet/sip-sol.spec.ts                            | 100 ++++++++  (new)
 tests/app/wallet/sip-stealth/page.test.tsx             |  +8 tests   (new)
 tests/app/wallet/sip-stealth/PublishCard.test.tsx      | +10 tests   (new)
 tests/components/payments/recipient-resolution.test.ts |  new        (new)
 tests/components/payments/recipient-input.test.tsx     |  47 → 463   (extended)
 tests/components/payments/send-shielded-form.test.tsx  |  new        (new)
 package.json + pnpm-lock.yaml                          |  +2 deps    (modified)
```

Depends on: `@sip-protocol/sns-stealth@^0.1.0` (npm, published in Phase A)
Plan: `sip-protocol/sip-protocol/docs/superpowers/plans/2026-05-11-sip-sol-foundation.md`