### PR TITLE
fix(docker): bump base image to node:22-alpine for pnpm v11 compat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # =============================================================================
 # Stage 1: Dependencies
 # =============================================================================
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 
 RUN apk add --no-cache libc6-compat
 RUN corepack enable && corepack prepare pnpm@latest --activate
@@ -17,7 +17,7 @@ RUN pnpm install --frozen-lockfile
 # =============================================================================
 # Stage 2: Builder
 # =============================================================================
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
@@ -38,7 +38,7 @@ RUN pnpm build
 # =============================================================================
 # Stage 3: Runner
 # =============================================================================
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Unblocks production deploy. `pnpm v11+` (resolved by `corepack prepare pnpm@latest --activate`) requires Node 22.5+'s built-in `node:sqlite`. The Dockerfile pinned `node:20-alpine` → every deploy since the Phase B merge has failed at `pnpm install --frozen-lockfile`.

## Root cause (from failed deploy logs of `d593956`):
```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
    at Module._load (node:internal/modules/cjs/loader:1031:13)
    at ../store/index/lib/index.js (pnpm/dist/pnpm.mjs:16044:25)
    at ../resolving/npm-resolver/lib/index.js (pnpm/dist/pnpm.mjs:26854:5)
```

The error chain is pnpm v11's own store implementation requiring `node:sqlite`. Not a sip-app dependency issue — purely a Node version mismatch between the Docker base and the pnpm version corepack pulls.

## Fix
Bump all three Dockerfile stages (`deps`, `builder`, `runner`) from `node:20-alpine` to `node:22-alpine`. Three-line change.

## Why Node 22 vs pinning pnpm to v10
- Node 22 is the **current LTS**; Node 20 is the older LTS already losing ecosystem support
- sipher's Dockerfile already uses `node:22-alpine` — same-org consistency
- Forward-compatible with future pnpm releases (rather than chasing a pinned version)
- Phase B's deps (`@sip-protocol/sns-stealth` + Bonfida transitive) increasingly want newer Node

## Test plan
- [ ] CI build-and-push succeeds (this PR's deploy run)
- [ ] Post-merge: app.sip-protocol.org serves Phase B routes (e.g. `/wallet/sip-stealth` returns 200, not 404)
- [ ] Phase E mainnet smoke test unblocked (can publish SIP-STEALTH record from sip-app UI)

## Context
- Phase B was merged in #269 (`d593956`) on 2026-05-11. Production has been serving pre-Phase B code (`c9cdda3` from 2026-04-08) since.
- This is a Phase E prerequisite — Phase D shipped to sipher this morning but the sip-app publish UI is needed to write SIP-STEALTH records before any end-to-end mainnet validation.