### PR TITLE
fix(docker): pin pnpm to 10.33.2 (matches local, fixes lockfile strict check)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM node:22-alpine AS deps
 
 RUN apk add --no-cache libc6-compat
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN pnpm install --frozen-lockfile
 # =============================================================================
 FROM node:22-alpine AS builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Follow-up to #271 (which bumped Node 20 → 22). With Node 22 + `pnpm@latest`, corepack now pulls **pnpm v11**, which fails `pnpm install --frozen-lockfile` with:

\`\`\`
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
\`\`\`

## Root cause
pnpm v11 introduced stricter lockfile config validation. It expects a settings hash for the `overrides` block — pnpm v10 (which generated this lockfile) doesn't write that hash. The overrides text is **identical** in `package.json` and `pnpm-lock.yaml`; v11 just fails the hash check.

## Fix
Pin to `pnpm@10.33.2` (matches the version used locally and in PR validate runs). Two-line change in the Dockerfile.

## Why pin 10.33.2 vs regenerate lockfile with v11
- Lockfile regeneration is large + risky — affects every transitive resolution
- Local dev runs pnpm 10.33.2 — pinning preserves dev/prod parity
- pnpm v11 migration is a separate concern; should be a deliberate PR with lockfile regeneration

## Test plan
- [ ] CI build-and-push succeeds with this fix
- [ ] Post-merge: app.sip-protocol.org serves Phase B routes (e.g. `/wallet/sip-stealth` returns 200)
- [ ] Phase E mainnet smoke test unblocked

## Context
- This continues the deploy unblocking started in #271
- Production has been broken since 2026-05-11 — Phase B (PR #269) merged but never reached app.sip-protocol.org
- Phase E (sip.sol foundation mainnet validation) is blocked behind this deploy