### PR TITLE
chore: configure sip-app for Vercel deployment

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,6 @@
+.next
+node_modules
+test-results
+playwright-report
+coverage
+*.tsbuildinfo

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,8 +9,10 @@ const utilBrowser = path.resolve(process.cwd(), "src/lib/util-browser.js")
 const yellowstoneStub = path.resolve(process.cwd(), "src/lib/yellowstone-grpc-stub.js")
 
 const nextConfig: NextConfig = {
-  // Enable standalone output for Docker deployment
-  output: "standalone",
+  // Standalone output for the Docker/VPS rollback build. On Vercel, leave it
+  // unset so the platform's native build output is used (VERCEL=1 in Vercel
+  // builds). Keeps the VPS image (Dockerfile COPY .next/standalone) buildable.
+  output: process.env.VERCEL ? undefined : "standalone",
 
   // Strict mode for better error detection
   reactStrictMode: true,

--- a/src/app/api/privacy-score/route.ts
+++ b/src/app/api/privacy-score/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server"
-import { createSurveillanceAnalyzer } from "@sip-protocol/sdk"
 import { logger } from "@/lib/logger"
 
 // Basic Solana address validation (base58, 32-44 chars)
@@ -41,7 +40,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(mockResult)
     }
 
-    // Use real SDK analyzer
+    // Use real SDK analyzer. Imported lazily (not at module top level) so the
+    // mock path above never loads @sip-protocol/sdk. On Vercel's serverless
+    // runtime the SDK resolves to its ESM build, whose transitive
+    // `import { CommitmentLevel } from "@triton-one/yellowstone-grpc"` (a CJS
+    // module) fails native ESM named-export detection at load time. Keeping the
+    // import lazy means that failure only surfaces when a real Helius key is
+    // configured (this branch); the default mock path stays unaffected.
+    const { createSurveillanceAnalyzer } = await import("@sip-protocol/sdk")
     const analyzer = createSurveillanceAnalyzer({
       heliusApiKey,
       cluster:

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "next build --webpack"
+}


### PR DESCRIPTION
## What

Configure `sip-app` for deployment on Vercel as part of the VPS reclabs3 → Vercel migration (#4 of 5 in the sip-protocol suite; docs, blog, cdn already live on Vercel).

## Changes

- **`vercel.json`** — pin `buildCommand` to `next build --webpack`. `next.config.ts` aliases the gRPC/WASM stack (`@triton-one/yellowstone-grpc`, `@grpc/grpc-js`) out of the **client** bundle, and that aliasing is webpack-only (the `turbopack:` block intentionally can't alias `@grpc/grpc-js` — Turbopack's strict ESM export checking rejects the generic stubs). Next 16 defaults to Turbopack, which would ship a broken client bundle, so the build command must force webpack.
- **`next.config.ts`** — make `output: "standalone"` conditional on `!process.env.VERCEL`. The VPS Docker image (`Dockerfile` COPYs `.next/standalone`) still needs standalone output to keep building as the rollback target; Vercel uses its native build output.
- **`.vercelignore`** — exclude build artifacts/test output from CLI uploads (the Vercel CLI ignores `.gitignore`).

## Behavior parity

No functional change. Production builds today with only `NEXT_PUBLIC_RPC_URL` (see `.github/workflows/deploy.yml` build-args); that one var is set on Vercel (Production + Preview). All other env-gated features remain on their existing code fallbacks — identical to current prod. The VPS blue-green deploy stays live as rollback through the 7-day buffer.

## Verification

- [x] Local `pnpm build` (`next build --webpack`) passes — all routes built, no Turbopack, no gRPC/WASM crash
- [x] Vercel preview smoke-tested on `d341d6f`: **all 24 page routes 200**; `POST /api/privacy-score` 200 (fixed a Vercel-only ESM load crash, see below); `/api/advisor` 400-validation byte-identical to VPS. Dual local build (VPS-standalone + `VERCEL=1`) both exit 0; typecheck clean.



## Follow-up fix in this PR (`d341d6f`)

Preview smoke-testing caught a **Vercel-only regression** the host move exposed: `POST /api/privacy-score` returned 500 on Vercel (200 on VPS). Root cause: the route imported `createSurveillanceAnalyzer` from `@sip-protocol/sdk` at module top level. Vercel's serverless runtime loads the SDK's **ESM** build, whose transitive `import { CommitmentLevel } from "@triton-one/yellowstone-grpc"` (CJS) fails native ESM named-export detection → `SyntaxError` at function load, crashing every request including the default mock path. The VPS standalone server loads the SDK's **CJS** build, so it was unaffected. Fix: move the import to a lazy `await import()` inside the real-Helius-key branch, so the default mock path (current prod on both hosts) never loads the SDK. Parity restored.