### PR TITLE
chore: disable VPS deploy auto-trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,11 @@
 name: Deploy
 
+# VPS deploy disabled — app.sip-protocol.org is served from Vercel as of 2026-06-01.
+# The VPS containers on reclabs3 (sip-app-blue / sip-app-green) are intentionally
+# kept running until the 7-day stability buffer elapses (~2026-06-08) as a
+# rollback target. Re-enable by restoring the `push: branches: [main]` trigger
+# below if a VPS-side rollback becomes necessary.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

VPS deploy workflow (`deploy.yml`) was still firing on every push to main even though app.sip-protocol.org is now served from Vercel. This PR changes the `on:` trigger from `push: branches: [main]` to `workflow_dispatch:` only.

The workflow stays visible in the Actions tab and remains manually re-triggerable during the 7-day VPS stability buffer (~2026-06-08) if a rollback to VPS is needed.

## Context

- Vercel migration session: `[vercel_migration_1]` 2026-05-26 (planning) → 2026-06-01 (sip-app cutover)
- DNS for app.sip-protocol.org points to Vercel
- VPS containers (sip-app-blue port 5005 / sip-app-green) intentionally kept running until 2026-06-08 as rollback target
- Decom runbook: `~/Documents/secret/claude-strategy/vercel-migration/VPS_DECOM_RUNBOOK.md`

## Reversal

Restore the `push: branches: [main]` block in the `on:` clause and merge.

## Test plan

- [x] Pushing to this branch should NOT trigger `deploy.yml` (only CI / mirror-gitlab run)
- [ ] After merge: confirm next push to main does not start a deploy run